### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,19 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
+      - name: Get version from tag
+        env:
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          export CURRENT_VERSION=${GITHUB_TAG/refs\/tags\/v/}
+          echo "::set-env name=CURRENT_VERSION::$CURRENT_VERSION"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Get Changelog Entry
         id: changelog_reader
         uses: mindsers/changelog-reader-action@v1.1.0
         with:
-          version: ${{ github.ref }}
+          version: ${{ env.CURRENT_VERSION }}
           path: ./CHANGELOG.md
       - name: Create Release
         id: create_release


### PR DESCRIPTION
Fixed the workflow example. As `gitlab.ref` value is **/refs/tags/v1.0.0**, the action always gets the recent changelog version.
I have created a new environment variable, that removes the **/refs/tags/v** part.