### PR TITLE
Support for unreleased entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New support for "Unreleased" section. It is possible to ask for the "Unreleased" section
+  by setting `version: "Unreleased"` in the `workflow.yml` file.
+
 ### Fixed
 - Improve the way the project is linted
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Create a workflow `.yml` file in your repositories `.github/workflows` directory
 ### Inputs
 
 - `path`: The path the action can find the CHANGELOG. Optional. Defaults to `./CHANGELOG.md`.
-- `version`: The exact version of the log entry you want to retreive. Optional. Defaults to last one.
+- `version`: The exact version of the log entry you want to retreive or "Unreleased" for the unreleased entry. Optional. Defaults to the last version number.
 
 ### Outputs
 
@@ -68,7 +68,7 @@ Contributions to the source code of *Changelog Reader Action* are welcomed and g
 
 ## Support
 
-*Changelog Reader Action* is licensed under an MIT license, which means that it's a completely free open source software. Unfortunately, *Changelog Reader Action* doesn't make itself. Version 1.1.0 is the next step, which will result in many late, beer-filled nights of development.
+*Changelog Reader Action* is licensed under an MIT license, which means that it's a completely free open source software. Unfortunately, *Changelog Reader Action* doesn't make itself. Version 2.0.0 is the next step, which will result in many late, beer-filled nights of development.
 
 If you're using *Changelog Reader Action* and want to support the development, you now have the chance! Go on my [Github Sponsor page](https://github.com/sponsors/mindsers) and become my joyful sponsor!!
 

--- a/src/get-entries.js
+++ b/src/get-entries.js
@@ -1,7 +1,7 @@
 const core = require('@actions/core')
 
 const versionSeparator = '\n## '
-const avoidNonVersionData = version => /^\[v?[0-9]+(\.[0-9]+){0,2}\]/.test(version)
+const avoidNonVersionData = version => /^\[(v?[0-9]+(\.[0-9]+){0,2}|unreleased)\]/i.test(version)
 
 exports.getEntries = (rawData) => {
     const content = String(rawData)

--- a/src/get-entries.test.js
+++ b/src/get-entries.test.js
@@ -56,14 +56,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 test('retreive entries from test (tag patern: vX.X.X)', () => {
   const output = getEntries(DATA_v)
+  const versionRegex = /^\[(v[0-1]+|unreleased)/i
 
-  expect(output.length).toEqual(2)
-  expect(output[0]).toMatch(/^\[v[0-1]+/)
+  expect(output.length).toEqual(3)
+  expect(output[0]).toMatch(versionRegex)
+  expect(output[1]).toMatch(versionRegex)
+  expect(output[2]).toMatch(versionRegex)
 })
 
 test('retreive entries from test (tag patern: X.X.X)', () => {
   const output = getEntries(DATA)
+  const versionRegex = /^\[([0-1]+|unreleased)/i
 
-  expect(output.length).toEqual(2)
-  expect(output[0]).toMatch(/^\[[0-1]+/)
+  expect(output.length).toEqual(3)
+  expect(output[0]).toMatch(versionRegex)
+  expect(output[1]).toMatch(versionRegex)
+  expect(output[2]).toMatch(versionRegex)
 })

--- a/src/get-version-by-id.js
+++ b/src/get-version-by-id.js
@@ -7,5 +7,7 @@ exports.getVersionById = (versions, id) => {
     }
   }
 
-  return [...versions].shift()
+  return [...versions]
+    .filter(version => !['Unreleased', 'unreleased'].includes(version.id))
+    .shift()
 }

--- a/src/get-version-by-id.test.js
+++ b/src/get-version-by-id.test.js
@@ -3,6 +3,10 @@ const { getVersionById } = require('./get-version-by-id')
 test('get latest if no version provided', () => {
   const input = [
     {
+      id: 'Unreleased',
+      text: `blablabla`
+    },
+    {
       id: 'v2.0.2',
       date: '2019-12-08',
       text: `blablabla`
@@ -15,11 +19,15 @@ test('get latest if no version provided', () => {
   ]
   const output = getVersionById(input)
 
-  expect(output.id).toEqual(input[0].id)
+  expect(output.id).toEqual(input[1].id)
 })
 
 test('get latest if bad version provided', () => {
   const input = [
+    {
+      id: 'Unreleased',
+      text: `blablabla`
+    },
     {
       id: 'v2.0.2',
       date: '2019-12-08',
@@ -33,11 +41,15 @@ test('get latest if bad version provided', () => {
   ]
   const output = getVersionById(input, 'v1.2.12')
 
-  expect(output.id).toEqual(input[0].id)
+  expect(output.id).toEqual(input[1].id)
 })
 
 test('support X.X.X version patern', () => {
   const input = [
+    {
+      id: 'Unreleased',
+      text: `blablabla`
+    },
     {
       id: 'v2.0.2',
       date: '2019-12-08',
@@ -62,6 +74,10 @@ test('support X.X.X version patern', () => {
 test('get the correct version', () => {
   const input = [
     {
+      id: 'Unreleased',
+      text: `blablabla`
+    },
+    {
       id: 'v2.1.1',
       date: '2019-12-08',
       text: `blablabla`
@@ -84,5 +100,5 @@ test('get the correct version', () => {
   ]
   const output = getVersionById(input, 'v2.1.0')
 
-  expect(output.id).toEqual(input[1].id)
+  expect(output.id).toEqual(input[2].id)
 })

--- a/src/get-version-by-id.test.js
+++ b/src/get-version-by-id.test.js
@@ -102,3 +102,35 @@ test('get the correct version', () => {
 
   expect(output.id).toEqual(input[2].id)
 })
+
+test('get the unreleased version', () => {
+  const input = [
+    {
+      id: 'Unreleased',
+      text: `blablabla`
+    },
+    {
+      id: 'v2.1.1',
+      date: '2019-12-08',
+      text: `blablabla`
+    },
+    {
+      id: 'v2.1.0',
+      date: '2019-12-02',
+      text: `blablabla`
+    },
+    {
+      id: 'v2.0.0',
+      date: '2019-12-02',
+      text: `blablabla`
+    },
+    {
+      id: 'v1.2.12',
+      date: '2019-12-02',
+      text: `blablabla`
+    },
+  ]
+  const output = getVersionById(input, 'Unreleased')
+
+  expect(output.id).toEqual(input[0].id)
+})

--- a/src/parse-entry.test.js
+++ b/src/parse-entry.test.js
@@ -135,3 +135,37 @@ test('get readable data from text entry | raw version number', () => {
   expect(output.text).toContain(`ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.`)
   expect(output.text).toContain(`**SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.`)
 })
+
+test('get readable data from text entry | unreleased version', () => {
+  const input = `
+    ## [Unreleased]
+    ### Added
+    - New attribute isOrdered on TextFieldList. Basicaly, <ol> becomes <ul> when not ordered.
+    - It is possible to change the row count of the TextField in TextFieldList.
+    - New attribute maxFieldCount on TextFieldList. It hides the add button when the value of maxFieldCount is reached.
+    - New DatePickerField component to display a date input.
+    - New attribute isSmall on TextField to display a smaller version of he TextField.
+
+    ### Changed
+    - All form components can be updated using the value attribute.
+    - **BREACKING CHANGES** The default behavior of TextFieldList is to be "not ordered".
+      You'll have to add the new isOrdered attribute on your existing components.
+    - FormErrors become FormErrorMessages.
+    - FormErrorMessages try to translate the error key automatically.
+    - ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.
+    - FormErrorMessages filter error that are equal to false
+    - If an error is equal to en object instead of true, the object is passed to the translator as variables by FormErrorMessages.
+    - RadioButton and CheckboxButton support other type than string for their children attribute.
+
+    ### Fixed
+    - Update types to allow no theme data into ThemeProvider.
+    - **SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.
+  `
+  const output = parseEntry(input)
+
+  expect(output.id).toEqual('Unreleased')
+  expect(output.date).toBeUndefined
+  expect(output.text).toContain(`### Added`)
+  expect(output.text).toContain(`ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.`)
+  expect(output.text).toContain(`**SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.`)
+})


### PR DESCRIPTION
The PR adds support for *unreleased entries*. (Closes #4)

Currently behavior doesn't change:
- If asking for a version number it returns a version number
- If asking for the unreleased entry it returns the unreleased entry
- If running the action without asking for something specific it returns the entry with the last version number **(not the unreleased entry)**