### PR TITLE
Full support of SEMVER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Improve SEMVER support. Now recognize complex version number based on https://semver.org.
 
 ## [1.2.0] - 2020-06-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Dates should follow the format used in the ["Keep a Changelog"](https://keepachangelog.com/en/1.0.0/) specification
+  which is `YYYY-MM-DD`. Another format that may work is `YYYY-DD-MM`.
+  Given the current disclaimer in the `README.md`, this change is **not** a *breaking* change.
+
+### Fixed
 - Improve SEMVER support. Now recognize complex version number based on https://semver.org.
 
 ## [1.2.0] - 2020-06-24

--- a/src/get-entries.js
+++ b/src/get-entries.js
@@ -1,7 +1,9 @@
 const core = require('@actions/core')
 
 const versionSeparator = '\n## '
-const avoidNonVersionData = version => /^\[(v?[0-9]+(\.[0-9]+){0,2}|unreleased)\]/i.test(version)
+const semverLinkRegex = /^\[v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?\]/
+const unreleasedLinkRegex = /^\[unreleased\]/i
+const avoidNonVersionData = version => semverLinkRegex.test(version) || unreleasedLinkRegex.test(version)
 
 exports.getEntries = (rawData) => {
     const content = String(rawData)

--- a/src/get-entries.test.js
+++ b/src/get-entries.test.js
@@ -27,6 +27,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.0]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0
 `
 
+const DATA_complex = `
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.2+meta]
+### Added
+- The project has now a CHANGELOG
+
+### Fixed
+- README now uses the correct version number in the examples
+
+## [1.1.1-rc.1+build.123] - 2020-02-12
+### Fixed
+- Remove template's old behavior
+
+## [1.1.1-DEV-SNAPSHOT] - 2020-02-12
+### Added
+- CHANGELOG can be parsed by the github action
+
+## [1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay] - 2019-12-09
+### Added
+- CHANGELOG can be parsed by the github action
+
+[1.1.2+meta]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.1-rc.1+build.123...1.1.2+meta
+[1.1.1-rc.1+build.123]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-rc.1+build.123
+[1.1.1-DEV-SNAPSHOT]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-DEV-SNAPSHOT
+[1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay
+`
+
 const DATA = `
 # Changelog
 All notable changes to this project will be documented in this file.
@@ -72,4 +104,16 @@ test('retreive entries from test (tag patern: X.X.X)', () => {
   expect(output[0]).toMatch(versionRegex)
   expect(output[1]).toMatch(versionRegex)
   expect(output[2]).toMatch(versionRegex)
+})
+
+// https://github.com/mindsers/changelog-reader-action/issues/8
+test('retreive entries from test (complex SEMVER)', () => {
+  const output = getEntries(DATA_complex)
+  const versionRegex = /^\[(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/
+
+  expect(output.length).toEqual(4)
+  expect(output[0]).toMatch(versionRegex)
+  expect(output[1]).toMatch(versionRegex)
+  expect(output[2]).toMatch(versionRegex)
+  expect(output[3]).toMatch(versionRegex)
 })

--- a/src/parse-entry.js
+++ b/src/parse-entry.js
@@ -1,12 +1,10 @@
-const capturingVersionAndDateRegex = /\[?(v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?|unreleased)\]?(\s+-\s+)?(.*)$/i
-
 exports.parseEntry = entry => {
   const [title, ...other] = entry
     .trim()
     .split('\n')
 
-  const [, versionNumber, ...lastCaptureGroup] = title.match(capturingVersionAndDateRegex)
-  const [versionDate] = lastCaptureGroup.reverse()
+  const [versionPart, versionDate] = title.split(' - ')
+  const [versionNumber] = versionPart.match(/[a-zA-ZZ0-9.\-+]+/)
 
   return {
     id: versionNumber.replace(/(\s)/g, ''),

--- a/src/parse-entry.js
+++ b/src/parse-entry.js
@@ -1,12 +1,15 @@
+const capturingVersionAndDateRegex = /\[?(v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?|unreleased)\]?(\s+-\s+)?(.*)$/i
+
 exports.parseEntry = entry => {
   const [title, ...other] = entry
     .trim()
     .split('\n')
 
-  const [versionNumber, versionDate] = title.replace(/(\[|\])/g, '').split(' - ')
+  const [, versionNumber, ...lastCaptureGroup] = title.match(capturingVersionAndDateRegex)
+  const [versionDate] = lastCaptureGroup.reverse()
 
   return {
-    id: versionNumber.match(/(\w|\.)/g).join(''),
+    id: versionNumber.replace(/(\s)/g, ''),
     date: versionDate,
     text: other
       .filter(item => !/\[.*\]: http/.test(item))

--- a/src/parse-entry.js
+++ b/src/parse-entry.js
@@ -3,11 +3,14 @@ exports.parseEntry = entry => {
     .trim()
     .split('\n')
 
-  const [versionPart, versionDate] = title.split(' - ')
-  const [versionNumber] = versionPart.match(/[a-zA-ZZ0-9.\-+]+/)
+  const [versionPart, datePart] = title.split(' - ')
+  const [versionNumber] = versionPart.match(/[a-zA-Z0-9.\-+]+/)
+  const [versionDate] = datePart != null
+    ? datePart.match(/[0-9-]+/)
+    : []
 
   return {
-    id: versionNumber.replace(/(\s)/g, ''),
+    id: versionNumber,
     date: versionDate,
     text: other
       .filter(item => !/\[.*\]: http/.test(item))

--- a/src/parse-entry.test.js
+++ b/src/parse-entry.test.js
@@ -136,6 +136,7 @@ test('get readable data from text entry | raw version number', () => {
   expect(output.text).toContain(`**SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.`)
 })
 
+// https://github.com/mindsers/changelog-reader-action/issues/4
 test('get readable data from text entry | unreleased version', () => {
   const input = `
     ## [Unreleased]
@@ -165,6 +166,41 @@ test('get readable data from text entry | unreleased version', () => {
 
   expect(output.id).toEqual('Unreleased')
   expect(output.date).toBeUndefined
+  expect(output.text).toContain(`### Added`)
+  expect(output.text).toContain(`ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.`)
+  expect(output.text).toContain(`**SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.`)
+})
+
+// https://github.com/mindsers/changelog-reader-action/issues/8
+test('get readable data from text entry | unreleased version', () => {
+  const input = `
+    ## [1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay] - 2019-02-10
+    ### Added
+    - New attribute isOrdered on TextFieldList. Basicaly, <ol> becomes <ul> when not ordered.
+    - It is possible to change the row count of the TextField in TextFieldList.
+    - New attribute maxFieldCount on TextFieldList. It hides the add button when the value of maxFieldCount is reached.
+    - New DatePickerField component to display a date input.
+    - New attribute isSmall on TextField to display a smaller version of he TextField.
+
+    ### Changed
+    - All form components can be updated using the value attribute.
+    - **BREACKING CHANGES** The default behavior of TextFieldList is to be "not ordered".
+      You'll have to add the new isOrdered attribute on your existing components.
+    - FormErrors become FormErrorMessages.
+    - FormErrorMessages try to translate the error key automatically.
+    - ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.
+    - FormErrorMessages filter error that are equal to false
+    - If an error is equal to en object instead of true, the object is passed to the translator as variables by FormErrorMessages.
+    - RadioButton and CheckboxButton support other type than string for their children attribute.
+
+    ### Fixed
+    - Update types to allow no theme data into ThemeProvider.
+    - **SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.
+  `
+  const output = parseEntry(input)
+
+  expect(output.id).toEqual('1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay')
+  expect(output.date).toEqual('2019-02-10')
   expect(output.text).toContain(`### Added`)
   expect(output.text).toContain(`ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.`)
   expect(output.text).toContain(`**SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.`)

--- a/src/parse-entry.test.js
+++ b/src/parse-entry.test.js
@@ -205,3 +205,37 @@ test('get readable data from text entry | unreleased version', () => {
   expect(output.text).toContain(`ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.`)
   expect(output.text).toContain(`**SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.`)
 })
+
+test('get readable data from text entry | unexpected characters between version and date', () => {
+  const input = `
+    ## [1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay] |+. - \\\\  2019-02-10
+    ### Added
+    - New attribute isOrdered on TextFieldList. Basicaly, <ol> becomes <ul> when not ordered.
+    - It is possible to change the row count of the TextField in TextFieldList.
+    - New attribute maxFieldCount on TextFieldList. It hides the add button when the value of maxFieldCount is reached.
+    - New DatePickerField component to display a date input.
+    - New attribute isSmall on TextField to display a smaller version of he TextField.
+
+    ### Changed
+    - All form components can be updated using the value attribute.
+    - **BREACKING CHANGES** The default behavior of TextFieldList is to be "not ordered".
+      You'll have to add the new isOrdered attribute on your existing components.
+    - FormErrors become FormErrorMessages.
+    - FormErrorMessages try to translate the error key automatically.
+    - ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.
+    - FormErrorMessages filter error that are equal to false
+    - If an error is equal to en object instead of true, the object is passed to the translator as variables by FormErrorMessages.
+    - RadioButton and CheckboxButton support other type than string for their children attribute.
+
+    ### Fixed
+    - Update types to allow no theme data into ThemeProvider.
+    - **SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.
+  `
+  const output = parseEntry(input)
+
+  expect(output.id).toEqual('1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay')
+  expect(output.date).toEqual('2019-02-10')
+  expect(output.text).toContain(`### Added`)
+  expect(output.text).toContain(`ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.`)
+  expect(output.text).toContain(`**SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.`)
+})

--- a/src/parse-entry.test.js
+++ b/src/parse-entry.test.js
@@ -1,29 +1,33 @@
 const { parseEntry } = require('./parse-entry')
 
+const entryDescription = `
+### Added
+- New attribute isOrdered on TextFieldList. Basicaly, <ol> becomes <ul> when not ordered.
+- It is possible to change the row count of the TextField in TextFieldList.
+- New attribute maxFieldCount on TextFieldList. It hides the add button when the value of maxFieldCount is reached.
+- New DatePickerField component to display a date input.
+- New attribute isSmall on TextField to display a smaller version of he TextField.
+
+### Changed
+- All form components can be updated using the value attribute.
+- **BREACKING CHANGES** The default behavior of TextFieldList is to be "not ordered".
+  You'll have to add the new isOrdered attribute on your existing components.
+- FormErrors become FormErrorMessages.
+- FormErrorMessages try to translate the error key automatically.
+- ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.
+- FormErrorMessages filter error that are equal to false
+- If an error is equal to en object instead of true, the object is passed to the translator as variables by FormErrorMessages.
+- RadioButton and CheckboxButton support other type than string for their children attribute.
+
+### Fixed
+- Update types to allow no theme data into ThemeProvider.
+- **SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.
+`
+
 test('get readable data from text entry', () => {
   const input = `
     ## [v0.0.26] - 2019-02-10
-    ### Added
-    - New attribute isOrdered on TextFieldList. Basicaly, <ol> becomes <ul> when not ordered.
-    - It is possible to change the row count of the TextField in TextFieldList.
-    - New attribute maxFieldCount on TextFieldList. It hides the add button when the value of maxFieldCount is reached.
-    - New DatePickerField component to display a date input.
-    - New attribute isSmall on TextField to display a smaller version of he TextField.
-
-    ### Changed
-    - All form components can be updated using the value attribute.
-    - **BREACKING CHANGES** The default behavior of TextFieldList is to be "not ordered".
-      You'll have to add the new isOrdered attribute on your existing components.
-    - FormErrors become FormErrorMessages.
-    - FormErrorMessages try to translate the error key automatically.
-    - ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.
-    - FormErrorMessages filter error that are equal to false
-    - If an error is equal to en object instead of true, the object is passed to the translator as variables by FormErrorMessages.
-    - RadioButton and CheckboxButton support other type than string for their children attribute.
-
-    ### Fixed
-    - Update types to allow no theme data into ThemeProvider.
-    - **SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.
+    ${entryDescription}
   `
   const output = parseEntry(input)
 
@@ -37,27 +41,7 @@ test('get readable data from text entry', () => {
 test('get readable data from text entry | no title for version', () => {
   const input = `
     [v0.0.26] - 2019-02-10
-    ### Added
-    - New attribute isOrdered on TextFieldList. Basicaly, <ol> becomes <ul> when not ordered.
-    - It is possible to change the row count of the TextField in TextFieldList.
-    - New attribute maxFieldCount on TextFieldList. It hides the add button when the value of maxFieldCount is reached.
-    - New DatePickerField component to display a date input.
-    - New attribute isSmall on TextField to display a smaller version of he TextField.
-
-    ### Changed
-    - All form components can be updated using the value attribute.
-    - **BREACKING CHANGES** The default behavior of TextFieldList is to be "not ordered".
-      You'll have to add the new isOrdered attribute on your existing components.
-    - FormErrors become FormErrorMessages.
-    - FormErrorMessages try to translate the error key automatically.
-    - ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.
-    - FormErrorMessages filter error that are equal to false
-    - If an error is equal to en object instead of true, the object is passed to the translator as variables by FormErrorMessages.
-    - RadioButton and CheckboxButton support other type than string for their children attribute.
-
-    ### Fixed
-    - Update types to allow no theme data into ThemeProvider.
-    - **SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.
+    ${entryDescription}
   `
   const output = parseEntry(input)
 
@@ -71,27 +55,7 @@ test('get readable data from text entry | no title for version', () => {
 test('get readable data from text entry | version patern X.X.X', () => {
   const input = `
     [0.0.26] - 2019-02-10
-    ### Added
-    - New attribute isOrdered on TextFieldList. Basicaly, <ol> becomes <ul> when not ordered.
-    - It is possible to change the row count of the TextField in TextFieldList.
-    - New attribute maxFieldCount on TextFieldList. It hides the add button when the value of maxFieldCount is reached.
-    - New DatePickerField component to display a date input.
-    - New attribute isSmall on TextField to display a smaller version of he TextField.
-
-    ### Changed
-    - All form components can be updated using the value attribute.
-    - **BREACKING CHANGES** The default behavior of TextFieldList is to be "not ordered".
-      You'll have to add the new isOrdered attribute on your existing components.
-    - FormErrors become FormErrorMessages.
-    - FormErrorMessages try to translate the error key automatically.
-    - ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.
-    - FormErrorMessages filter error that are equal to false
-    - If an error is equal to en object instead of true, the object is passed to the translator as variables by FormErrorMessages.
-    - RadioButton and CheckboxButton support other type than string for their children attribute.
-
-    ### Fixed
-    - Update types to allow no theme data into ThemeProvider.
-    - **SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.
+    ${entryDescription}
   `
   const output = parseEntry(input)
 
@@ -105,27 +69,7 @@ test('get readable data from text entry | version patern X.X.X', () => {
 test('get readable data from text entry | raw version number', () => {
   const input = `
     v0.0.26 - 2019-02-10
-    ### Added
-    - New attribute isOrdered on TextFieldList. Basicaly, <ol> becomes <ul> when not ordered.
-    - It is possible to change the row count of the TextField in TextFieldList.
-    - New attribute maxFieldCount on TextFieldList. It hides the add button when the value of maxFieldCount is reached.
-    - New DatePickerField component to display a date input.
-    - New attribute isSmall on TextField to display a smaller version of he TextField.
-
-    ### Changed
-    - All form components can be updated using the value attribute.
-    - **BREACKING CHANGES** The default behavior of TextFieldList is to be "not ordered".
-      You'll have to add the new isOrdered attribute on your existing components.
-    - FormErrors become FormErrorMessages.
-    - FormErrorMessages try to translate the error key automatically.
-    - ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.
-    - FormErrorMessages filter error that are equal to false
-    - If an error is equal to en object instead of true, the object is passed to the translator as variables by FormErrorMessages.
-    - RadioButton and CheckboxButton support other type than string for their children attribute.
-
-    ### Fixed
-    - Update types to allow no theme data into ThemeProvider.
-    - **SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.
+    ${entryDescription}
   `
   const output = parseEntry(input)
 
@@ -140,27 +84,7 @@ test('get readable data from text entry | raw version number', () => {
 test('get readable data from text entry | unreleased version', () => {
   const input = `
     ## [Unreleased]
-    ### Added
-    - New attribute isOrdered on TextFieldList. Basicaly, <ol> becomes <ul> when not ordered.
-    - It is possible to change the row count of the TextField in TextFieldList.
-    - New attribute maxFieldCount on TextFieldList. It hides the add button when the value of maxFieldCount is reached.
-    - New DatePickerField component to display a date input.
-    - New attribute isSmall on TextField to display a smaller version of he TextField.
-
-    ### Changed
-    - All form components can be updated using the value attribute.
-    - **BREACKING CHANGES** The default behavior of TextFieldList is to be "not ordered".
-      You'll have to add the new isOrdered attribute on your existing components.
-    - FormErrors become FormErrorMessages.
-    - FormErrorMessages try to translate the error key automatically.
-    - ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.
-    - FormErrorMessages filter error that are equal to false
-    - If an error is equal to en object instead of true, the object is passed to the translator as variables by FormErrorMessages.
-    - RadioButton and CheckboxButton support other type than string for their children attribute.
-
-    ### Fixed
-    - Update types to allow no theme data into ThemeProvider.
-    - **SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.
+    ${entryDescription}
   `
   const output = parseEntry(input)
 
@@ -175,27 +99,7 @@ test('get readable data from text entry | unreleased version', () => {
 test('get readable data from text entry | unreleased version', () => {
   const input = `
     ## [1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay] - 2019-02-10
-    ### Added
-    - New attribute isOrdered on TextFieldList. Basicaly, <ol> becomes <ul> when not ordered.
-    - It is possible to change the row count of the TextField in TextFieldList.
-    - New attribute maxFieldCount on TextFieldList. It hides the add button when the value of maxFieldCount is reached.
-    - New DatePickerField component to display a date input.
-    - New attribute isSmall on TextField to display a smaller version of he TextField.
-
-    ### Changed
-    - All form components can be updated using the value attribute.
-    - **BREACKING CHANGES** The default behavior of TextFieldList is to be "not ordered".
-      You'll have to add the new isOrdered attribute on your existing components.
-    - FormErrors become FormErrorMessages.
-    - FormErrorMessages try to translate the error key automatically.
-    - ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.
-    - FormErrorMessages filter error that are equal to false
-    - If an error is equal to en object instead of true, the object is passed to the translator as variables by FormErrorMessages.
-    - RadioButton and CheckboxButton support other type than string for their children attribute.
-
-    ### Fixed
-    - Update types to allow no theme data into ThemeProvider.
-    - **SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.
+    ${entryDescription}
   `
   const output = parseEntry(input)
 
@@ -209,27 +113,7 @@ test('get readable data from text entry | unreleased version', () => {
 test('get readable data from text entry | unexpected characters between version and date', () => {
   const input = `
     ## [1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay] |+. - \\\\  2019-02-10
-    ### Added
-    - New attribute isOrdered on TextFieldList. Basicaly, <ol> becomes <ul> when not ordered.
-    - It is possible to change the row count of the TextField in TextFieldList.
-    - New attribute maxFieldCount on TextFieldList. It hides the add button when the value of maxFieldCount is reached.
-    - New DatePickerField component to display a date input.
-    - New attribute isSmall on TextField to display a smaller version of he TextField.
-
-    ### Changed
-    - All form components can be updated using the value attribute.
-    - **BREACKING CHANGES** The default behavior of TextFieldList is to be "not ordered".
-      You'll have to add the new isOrdered attribute on your existing components.
-    - FormErrors become FormErrorMessages.
-    - FormErrorMessages try to translate the error key automatically.
-    - ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.
-    - FormErrorMessages filter error that are equal to false
-    - If an error is equal to en object instead of true, the object is passed to the translator as variables by FormErrorMessages.
-    - RadioButton and CheckboxButton support other type than string for their children attribute.
-
-    ### Fixed
-    - Update types to allow no theme data into ThemeProvider.
-    - **SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.
+    ${entryDescription}
   `
   const output = parseEntry(input)
 


### PR DESCRIPTION
Improve the SEMVER support to make possible complex SEMVER version number recognition. 

It uses the [official regex](https://regex101.com/r/vkijKf/1/) to check version number.

_PS: The PR also adds a "kind of a check" on dates but as the `README.md` explained, this is NOT a breaking change:_
> _**This action only work if your `CHANGELOG.md` file follows the [_Keep a Changelog_](https://github.com/olivierlacan/keep-a-changelog) standard for now.**_