### PR TITLE
Fix fake date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Allow developers to NOT use a date for each version entries.
 
 ## [1.3.0] - 2020-07-06
 ### Changed

--- a/src/parse-entry.js
+++ b/src/parse-entry.js
@@ -6,7 +6,7 @@ exports.parseEntry = entry => {
   const [versionPart, datePart] = title.split(' - ')
   const [versionNumber] = versionPart.match(/[a-zA-Z0-9.\-+]+/)
   const [versionDate] = datePart != null
-    ? datePart.match(/[0-9-]+/)
+    ? (datePart.match(/[0-9-]+/) || [])
     : []
 
   return {

--- a/src/parse-entry.js
+++ b/src/parse-entry.js
@@ -5,9 +5,7 @@ exports.parseEntry = entry => {
 
   const [versionPart, datePart] = title.split(' - ')
   const [versionNumber] = versionPart.match(/[a-zA-Z0-9.\-+]+/)
-  const [versionDate] = datePart != null
-    ? (datePart.match(/[0-9-]+/) || [])
-    : []
+  const [versionDate] = datePart != null && datePart.match(/[0-9-]+/) || []
 
   return {
     id: versionNumber,

--- a/src/parse-entry.test.js
+++ b/src/parse-entry.test.js
@@ -89,7 +89,7 @@ test('get readable data from text entry | unreleased version', () => {
   const output = parseEntry(input)
 
   expect(output.id).toEqual('Unreleased')
-  expect(output.date).toBeUndefined
+  expect(output.date).toBeUndefined()
   expect(output.text).toContain(`### Added`)
   expect(output.text).toContain(`ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.`)
   expect(output.text).toContain(`**SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.`)
@@ -119,6 +119,21 @@ test('get readable data from text entry | unexpected characters between version 
 
   expect(output.id).toEqual('1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay')
   expect(output.date).toEqual('2019-02-10')
+  expect(output.text).toContain(`### Added`)
+  expect(output.text).toContain(`ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.`)
+  expect(output.text).toContain(`**SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.`)
+})
+
+// https://github.com/mindsers/changelog-reader-action/issues/10
+test('get readable data from text entry | Fake date', () => {
+  const input = `
+    ## [1.0.0] - SomeWords instead of a Date
+    ${entryDescription}
+  `
+  const output = parseEntry(input)
+
+  expect(output.id).toEqual('1.0.0')
+  expect(output.date).toBeUndefined()
   expect(output.text).toContain(`### Added`)
   expect(output.text).toContain(`ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.`)
   expect(output.text).toContain(`**SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.`)


### PR DESCRIPTION
The action will now ignore Changelog entries where the date isn't actually a `Date`. 

Fix #10 