### PR TITLE
feature/failOnInvalidVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- If given a specific target version, action will now generate an error response if that version is not found in the changelog.
+- **[BREAKING CHANGE]** If given a specific target version, action will now generate an error response if that version is not found in the changelog.
 
 ## [1.3.1] - 2020-07-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- If given a specific target version, action will now generate an error response if that version is not found in the changelog.
 
 ## [1.3.1] - 2020-07-08
 ### Fixed

--- a/dist/index.js
+++ b/dist/index.js
@@ -82,7 +82,7 @@ const readFile  = utils.promisify(fs.readFile)
 exports.main = async function main() {
   try {
     const changelogPath = core.getInput('path') || './CHANGELOG.md'
-    const targetVersion = core.getInput('version')
+    const targetVersion = core.getInput('version') || null
 
     if (targetVersion == null) {
       core.warning(`No target version specified. try to return the most recent one in the changelog file.`)
@@ -98,10 +98,10 @@ exports.main = async function main() {
 
     const version = getVersionById(versions, targetVersion)
 
-    if (version == null) {
-      core.error('No log entry found.')
-      core.setOutput('log_entry', '')
-      return
+    if (version == null && targetVersion != null) {
+      throw new Error(`No log entry found for target version ${targetVersion}.`)
+    } else if (version == null) {
+      throw new Error('No log entry found.')
     }
 
     core.setOutput('log_entry', version.text)
@@ -437,11 +437,7 @@ exports.getState = getState;
 
 exports.getVersionById = (versions, id) => {
   if (id != null) {
-    const version = versions.find(version => version.id === id)
-
-    if (version != null) {
-      return version
-    }
+    return versions.find(version => version.id === id)
   }
 
   return [...versions]

--- a/src/get-version-by-id.js
+++ b/src/get-version-by-id.js
@@ -1,10 +1,6 @@
 exports.getVersionById = (versions, id) => {
   if (id != null) {
-    const version = versions.find(version => version.id === id)
-
-    if (version != null) {
-      return version
-    }
+    return versions.find(version => version.id === id)
   }
 
   return [...versions]

--- a/src/get-version-by-id.test.js
+++ b/src/get-version-by-id.test.js
@@ -22,7 +22,7 @@ test('get latest if no version provided', () => {
   expect(output.id).toEqual(input[1].id)
 })
 
-test('get latest if bad version provided', () => {
+test('return null if bad version provided', () => {
   const input = [
     {
       id: 'Unreleased',
@@ -41,7 +41,7 @@ test('get latest if bad version provided', () => {
   ]
   const output = getVersionById(input, 'v1.2.12')
 
-  expect(output.id).toEqual(input[1].id)
+  expect(output).toBeUndefined()
 })
 
 test('support X.X.X version patern', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -27,10 +27,12 @@ exports.main = async function main() {
 
     const version = getVersionById(versions, targetVersion)
 
-    if (version == null && targetVersion != null) {
-      throw new Error(`No log entry found for target version ${targetVersion}.`)
-    } else if (version == null) {
-      throw new Error('No log entry found.')
+    if (version == null) {
+      throw new Error(`No log entry found${
+        targetVersion != null
+          ? ` for version ${targetVersion}`
+          : ''
+      }`)
     }
 
     core.setOutput('log_entry', version.text)

--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,7 @@ const readFile  = utils.promisify(fs.readFile)
 exports.main = async function main() {
   try {
     const changelogPath = core.getInput('path') || './CHANGELOG.md'
-    const targetVersion = core.getInput('version')
+    const targetVersion = core.getInput('version') || null
 
     if (targetVersion == null) {
       core.warning(`No target version specified. try to return the most recent one in the changelog file.`)
@@ -27,10 +27,10 @@ exports.main = async function main() {
 
     const version = getVersionById(versions, targetVersion)
 
-    if (version == null) {
-      core.error('No log entry found.')
-      core.setOutput('log_entry', '')
-      return
+    if (version == null && targetVersion != null) {
+      throw new Error(`No log entry found for target version ${targetVersion}.`)
+    } else if (version == null) {
+      throw new Error('No log entry found.')
     }
 
     core.setOutput('log_entry', version.text)


### PR DESCRIPTION
Updated response to produce error if specified target version was not found. Fixes mindsers/changelog-reader-action#16

This was pulled out of PR #17