### PR TITLE
Support Angular and other changelog formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Introduced changelog validation to help keep the release version in line with [Semantic Versioning](https://semver.org/)
 - New input param of `validation_depth` to allow for configuration of changelog validation.
+- Support Angular CHANGELOG format. (Doesn't force title emphasis)
 
 ### Changed
 - The project now implement the [All Contributors](https://allcontributors.org).

--- a/src/get-entries.js
+++ b/src/get-entries.js
@@ -1,6 +1,6 @@
 const core = require('@actions/core')
 
-const versionSeparator = '\n## '
+const versionSeparator = /\n#{1,3}\s/
 const semverLinkRegex = /^\[v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?\]/
 const unreleasedLinkRegex = /^\[unreleased\]/i
 const avoidNonVersionData = version => semverLinkRegex.test(version) || unreleasedLinkRegex.test(version)


### PR DESCRIPTION
This simple change allow the action to work with angular and other presets where min/patch/major versions might not be emphasis the same way through the number of `#` before the version.
All tests are passing as they are. I did not modify the tests for the other templates but i tested locally and they work