### PR TITLE
Retrieve independent links from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   *This is not a change in the code but a change in how the projet recognize the
   external contributions.*
 
+### Fixed
+- Retrieve links (external to the entry) and add them back in the related entry.
+
 ## [2.0.0] - 2020-08-30
 ### Added
 - New output properties:

--- a/src/add-links.js
+++ b/src/add-links.js
@@ -2,16 +2,20 @@ const core = require("@actions/core");
 
 exports.addLinks = (links) => (entry) => {
   const { text } = entry;
-  const [, ...usedLinks] = /(\[.+\])\[\]/g.exec(text) || [];
+  const linkRegex = /(\[.+\])\[\]/gi;
 
   let tempText = `${text}`;
-  for (const usedLink of usedLinks) {
-    const link = links.find((element) => element.includes(usedLink));
+  while (true) {
+    const results = linkRegex.exec(text);
 
-    tempText = `${tempText}
+    if (results == null) {
+      break;
+    }
 
-    ${link}`;
+    const link = links.find((element) => element.includes(results[1]));
+
+    tempText = tempText + "\n" + link;
   }
 
-  return { ...entry, text: tempText };
+  return { ...entry, text: tempText.trim() };
 };

--- a/src/add-links.js
+++ b/src/add-links.js
@@ -1,0 +1,17 @@
+const core = require("@actions/core");
+
+exports.addLinks = (links) => (entry) => {
+  const { text } = entry;
+  const [, ...usedLinks] = /(\[.+\])\[\]/g.exec(text) || [];
+
+  let tempText = `${text}`;
+  for (const usedLink of usedLinks) {
+    const link = links.find((element) => element.includes(usedLink));
+
+    tempText = `${tempText}
+
+    ${link}`;
+  }
+
+  return { ...entry, text: tempText };
+};

--- a/src/add-links.js
+++ b/src/add-links.js
@@ -1,21 +1,21 @@
-const core = require("@actions/core");
+const core = require('@actions/core')
 
-exports.addLinks = (links) => (entry) => {
-  const { text } = entry;
-  const linkRegex = /(\[.+\])\[\]/gi;
+exports.addLinks = links => entry => {
+  const { text } = entry
+  const linkRegex = /(\[.+\])\[\]/gi
 
-  let tempText = `${text}`;
+  let tempText = `${text}`
   while (true) {
-    const results = linkRegex.exec(text);
+    const results = linkRegex.exec(text)
 
     if (results == null) {
-      break;
+      break
     }
 
-    const link = links.find((element) => element.includes(results[1]));
+    const link = links.find(element => element.includes(results[1]))
 
-    tempText = tempText + "\n" + link;
+    tempText = tempText + '\n' + link
   }
 
-  return { ...entry, text: tempText.trim() };
-};
+  return { ...entry, text: tempText.trim() }
+}

--- a/src/add-links.js
+++ b/src/add-links.js
@@ -1,20 +1,12 @@
-const core = require('@actions/core')
-
 exports.addLinks = links => entry => {
   const { text } = entry
   const linkRegex = /(\[.+\])\[\]/gi
 
   let tempText = `${text}`
-  while (true) {
-    const results = linkRegex.exec(text)
-
-    if (results == null) {
-      break
-    }
-
+  let results = null
+  while ((results = linkRegex.exec(text)) != null) {
     const link = links.find(element => element.includes(results[1]))
-
-    tempText = tempText + '\n' + link
+    tempText = `${tempText}\n${link}`
   }
 
   return { ...entry, text: tempText.trim() }

--- a/src/add-links.test.js
+++ b/src/add-links.test.js
@@ -1,6 +1,6 @@
-const { addLinks } = require("./add-links");
+const { addLinks } = require('./add-links')
 
-test("retreive add correct links to entry", () => {
+test('retreive add correct links to entry', () => {
   const output = addLinks([
     `[1.1.2+meta]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.1-rc.1+build.123...1.1.2+meta`,
     `[1.1.1-rc.1+build.123]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-rc.1+build.123`,
@@ -11,7 +11,7 @@ test("retreive add correct links to entry", () => {
     text: `### Added
 - CHANGELOG can be parsed by the [github][] action
 - [1.1.1-DEV-SNAPSHOT][] can be parsed by the github action`,
-  });
+  })
 
   expect(output.text).toEqual(
     `### Added
@@ -19,10 +19,10 @@ test("retreive add correct links to entry", () => {
 - [1.1.1-DEV-SNAPSHOT][] can be parsed by the github action
 [github]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay
 [1.1.1-DEV-SNAPSHOT]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-DEV-SNAPSHOT`
-  );
-});
+  )
+})
 
-test("add nothing when there is no references", () => {
+test('add nothing when there is no references', () => {
   const output = addLinks([
     `[1.1.2+meta]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.1-rc.1+build.123...1.1.2+meta`,
     `[1.1.1-rc.1+build.123]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-rc.1+build.123`,
@@ -31,8 +31,8 @@ test("add nothing when there is no references", () => {
   ])({
     text: `### Added
   - CHANGELOG can be parsed by the github action`,
-  });
+  })
 
   expect(output.text).toEqual(`### Added
-  - CHANGELOG can be parsed by the github action`);
-});
+  - CHANGELOG can be parsed by the github action`)
+})

--- a/src/add-links.test.js
+++ b/src/add-links.test.js
@@ -1,0 +1,31 @@
+const { addLinks } = require("./add-links");
+
+test("retreive add correct links to entry", () => {
+  const output = addLinks([
+    `[1.1.2+meta]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.1-rc.1+build.123...1.1.2+meta`,
+    `[1.1.1-rc.1+build.123]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-rc.1+build.123`,
+    `[1.1.1-DEV-SNAPSHOT]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-DEV-SNAPSHOT`,
+    `[1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay`,
+    `[github]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay`,
+  ])({
+    text: `### Added
+  - CHANGELOG can be parsed by the [github][] action
+  - [1.1.1-DEV-SNAPSHOT][] can be parsed by the github action`,
+  });
+
+  expect(output).toEqual(3);
+});
+
+test("add nothing when there is no references", () => {
+  const output = addLinks([
+    `[1.1.2+meta]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.1-rc.1+build.123...1.1.2+meta`,
+    `[1.1.1-rc.1+build.123]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-rc.1+build.123`,
+    `[1.1.1-DEV-SNAPSHOT]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-DEV-SNAPSHOT`,
+    `[1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay`,
+  ])({
+    text: `### Added
+  - CHANGELOG can be parsed by the github action`,
+  });
+
+  expect(output.length).toBeLessThan(1);
+});

--- a/src/add-links.test.js
+++ b/src/add-links.test.js
@@ -9,11 +9,17 @@ test("retreive add correct links to entry", () => {
     `[github]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay`,
   ])({
     text: `### Added
-  - CHANGELOG can be parsed by the [github][] action
-  - [1.1.1-DEV-SNAPSHOT][] can be parsed by the github action`,
+- CHANGELOG can be parsed by the [github][] action
+- [1.1.1-DEV-SNAPSHOT][] can be parsed by the github action`,
   });
 
-  expect(output).toEqual(3);
+  expect(output.text).toEqual(
+    `### Added
+- CHANGELOG can be parsed by the [github][] action
+- [1.1.1-DEV-SNAPSHOT][] can be parsed by the github action
+[github]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay
+[1.1.1-DEV-SNAPSHOT]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-DEV-SNAPSHOT`
+  );
 });
 
 test("add nothing when there is no references", () => {
@@ -27,5 +33,6 @@ test("add nothing when there is no references", () => {
   - CHANGELOG can be parsed by the github action`,
   });
 
-  expect(output.length).toBeLessThan(1);
+  expect(output.text).toEqual(`### Added
+  - CHANGELOG can be parsed by the github action`);
 });

--- a/src/get-links.js
+++ b/src/get-links.js
@@ -1,7 +1,7 @@
 const core = require('@actions/core')
 
 const linkRegex =
-  /^\[.+\]:\s?(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]+$/
+  /^\[.+\]:\s?(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/
 const avoidNonVersionData = text => linkRegex.test(text)
 
 exports.getLinks = rawData => {

--- a/src/get-links.js
+++ b/src/get-links.js
@@ -1,16 +1,13 @@
 const core = require('@actions/core')
 
 const linkRegex =
-  /^\[.+\]:\s?(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]+$/;
-const avoidNonVersionData = text => linkRegex.test(text);
+  /^\[.+\]:\s?(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]+$/
+const avoidNonVersionData = text => linkRegex.test(text)
 
 exports.getLinks = rawData => {
-  const content = String(rawData);
+  const content = String(rawData)
 
-  core.debug(`CHANGELOG content: ${content}`);
+  core.debug(`CHANGELOG content: ${content}`)
 
-  return content
-    .trim()
-    .split("\n")
-    .filter(avoidNonVersionData);
-};
+  return content.trim().split('\n').filter(avoidNonVersionData)
+}

--- a/src/get-links.js
+++ b/src/get-links.js
@@ -1,0 +1,16 @@
+const core = require('@actions/core')
+
+const linkRegex =
+  /^\[.+\]:\s?(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]+$/;
+const avoidNonVersionData = text => linkRegex.test(text);
+
+exports.getLinks = rawData => {
+  const content = String(rawData);
+
+  core.debug(`CHANGELOG content: ${content}`);
+
+  return content
+    .trim()
+    .split("\n")
+    .filter(avoidNonVersionData);
+};

--- a/src/get-links.test.js
+++ b/src/get-links.test.js
@@ -87,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `
 
 const linkRegex =
-  /^\[.+\]:\s?(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]+$/
+  /^\[.+\]:\s?(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/
 
 test('retreive links from test (tag patern: vX.X.X)', () => {
   const output = getLinks(DATA_v)

--- a/src/get-links.test.js
+++ b/src/get-links.test.js
@@ -1,4 +1,4 @@
-const { getLinks } = require("./get-links");
+const { getLinks } = require('./get-links')
 
 const DATA_v = `
 # Changelog
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.1...HEAD
 [1.0.1]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0
-`;
+`
 
 const DATA_complex = `
 # Changelog
@@ -57,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.1-rc.1+build.123]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-rc.1+build.123
 [1.1.1-DEV-SNAPSHOT]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-DEV-SNAPSHOT
 [1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay
-`;
+`
 
 const DATA = `
 # Changelog
@@ -84,35 +84,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.1...HEAD
 [1.0.1]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0
-`;
+`
 
 const linkRegex =
-  /^\[.+\]:\s?(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]+$/;
+  /^\[.+\]:\s?(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]+$/
 
-test("retreive links from test (tag patern: vX.X.X)", () => {
-  const output = getLinks(DATA_v);
+test('retreive links from test (tag patern: vX.X.X)', () => {
+  const output = getLinks(DATA_v)
 
-  expect(output.length).toEqual(3);
+  expect(output.length).toEqual(3)
   for (const text of output) {
-    expect(text).toMatch(linkRegex);
+    expect(text).toMatch(linkRegex)
   }
-});
+})
 
-test("retreive links from test (tag patern: X.X.X)", () => {
-  const output = getLinks(DATA);
+test('retreive links from test (tag patern: X.X.X)', () => {
+  const output = getLinks(DATA)
 
-  expect(output.length).toEqual(3);
+  expect(output.length).toEqual(3)
   for (const text of output) {
-    expect(text).toMatch(linkRegex);
+    expect(text).toMatch(linkRegex)
   }
-});
+})
 
 // https://github.com/mindsers/changelog-reader-action/issues/8
-test("retreive links from test (complex SEMVER)", () => {
-  const output = getLinks(DATA_complex);
+test('retreive links from test (complex SEMVER)', () => {
+  const output = getLinks(DATA_complex)
 
-  expect(output.length).toEqual(4);
+  expect(output.length).toEqual(4)
   for (const text of output) {
-    expect(text).toMatch(linkRegex);
+    expect(text).toMatch(linkRegex)
   }
-});
+})

--- a/src/get-links.test.js
+++ b/src/get-links.test.js
@@ -1,0 +1,118 @@
+const { getLinks } = require("./get-links");
+
+const DATA_v = `
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- The project has now a CHANGELOG
+
+### Fixed
+- README now uses the correct version number in the examples
+
+## [v1.0.1] - 2020-02-12
+### Fixed
+- Remove template's old behavior
+
+## [v1.0.0] - 2020-02-12
+### Added
+- CHANGELOG can be parsed by the github action
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0
+`;
+
+const DATA_complex = `
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.2+meta]
+### Added
+- The project has now a CHANGELOG
+
+### Fixed
+- README now uses the correct version number in the examples
+
+## [1.1.1-rc.1+build.123] - 2020-02-12
+### Fixed
+- Remove template's old behavior
+
+## [1.1.1-DEV-SNAPSHOT] - 2020-02-12
+### Added
+- CHANGELOG can be parsed by the github action
+
+## [1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay] - 2019-12-09
+### Added
+- CHANGELOG can be parsed by the github action
+
+[1.1.2+meta]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.1-rc.1+build.123...1.1.2+meta
+[1.1.1-rc.1+build.123]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-rc.1+build.123
+[1.1.1-DEV-SNAPSHOT]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay...v1.1.1-DEV-SNAPSHOT
+[1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay
+`;
+
+const DATA = `
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- The project has now a CHANGELOG
+
+### Fixed
+- README now uses the correct version number in the examples
+
+## [1.0.1] - 2020-02-12
+### Fixed
+- Remove template's old behavior
+
+## [1.0.0] - 2020-02-12
+### Added
+- CHANGELOG can be parsed by the github action
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/mindsers/changelog-reader-action/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/mindsers/changelog-reader-action/releases/tag/v1.0.0
+`;
+
+const linkRegex =
+  /^\[.+\]:\s?(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]+$/;
+
+test("retreive links from test (tag patern: vX.X.X)", () => {
+  const output = getLinks(DATA_v);
+
+  expect(output.length).toEqual(3);
+  for (const text of output) {
+    expect(text).toMatch(linkRegex);
+  }
+});
+
+test("retreive links from test (tag patern: X.X.X)", () => {
+  const output = getLinks(DATA);
+
+  expect(output.length).toEqual(3);
+  for (const text of output) {
+    expect(text).toMatch(linkRegex);
+  }
+});
+
+// https://github.com/mindsers/changelog-reader-action/issues/8
+test("retreive links from test (complex SEMVER)", () => {
+  const output = getLinks(DATA_complex);
+
+  expect(output.length).toEqual(4);
+  for (const text of output) {
+    expect(text).toMatch(linkRegex);
+  }
+});

--- a/src/main.js
+++ b/src/main.js
@@ -26,9 +26,7 @@ exports.main = async function main() {
     core.startGroup('Parse data')
     const rawData = await readFile(changelogPath)
     const linkList = getLinks(rawData)
-    const versions = getEntries(rawData)
-      .map(parseEntry)
-      .map(addLinks(linkList))
+    const versions = getEntries(rawData).map(parseEntry).map(addLinks(linkList))
 
     if (validationDepth != 0) {
       const releasedVersions = versions.filter(version => version.status != 'unreleased')

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ exports.main = async function main() {
 
     core.startGroup('Parse data')
     const rawData = await readFile(changelogPath)
+    const linkList = getLinks(rawData)
     const versions = getEntries(rawData)
       .map(parseEntry)
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ const { validateEntry } = require('./validate-entry')
 const { parseEntry } = require('./parse-entry')
 const { getEntries } = require('./get-entries')
 const { getVersionById } = require('./get-version-by-id')
+const { getLinks } = require('./get-links')
 const { addLinks } = require('./add-links')
 
 const readFile = utils.promisify(fs.readFile)

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ const { validateEntry } = require('./validate-entry')
 const { parseEntry } = require('./parse-entry')
 const { getEntries } = require('./get-entries')
 const { getVersionById } = require('./get-version-by-id')
+const { addLinks } = require('./add-links')
 
 const readFile  = utils.promisify(fs.readFile)
 
@@ -24,6 +25,7 @@ exports.main = async function main() {
     const linkList = getLinks(rawData)
     const versions = getEntries(rawData)
       .map(parseEntry)
+      .map(addLinks(linkList))
 
     if (validationDepth != 0)
     {


### PR DESCRIPTION
This PR retrieve the links from the raw CHANGELOG and put them back in the related CHANGELOG entry.

Fix #52 