### PR TITLE
Refactor validation before deploy

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,13 +8,17 @@ inputs:
     description: 'Path to the CHANGELOG file containing the log entries'
     required: false
     default: './CHANGELOG.md'
-  validation_depth:
-    description: 'Specifies how many entries to validate in the CHANGELOG.md file'
-    required: false
-    default: '0'
   version:
     description: 'Version of the log entry wanted'
     required: false
+  validation_level:
+    description: 'Specifies if the CHANGELOG.md file should be validated and the behavior of the action'
+    required: false
+    default: 'none'
+  validation_depth:
+    description: 'Specifies how many entries to validate in the CHANGELOG.md file'
+    required: false
+    default: '-1'
 outputs:
   version:
     description: 'Version of the log entry found'

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ const core = require('@actions/core')
 const { validateEntry } = require('./validate-entry')
 const { parseEntry } = require('./parse-entry')
 const { getEntries } = require('./get-entries')
-const { getVersionById } = require('./get-version-by-id')
+const { getVersionById: getEntryByVersionID } = require('./get-version-by-id')
 
 const readFile = utils.promisify(fs.readFile)
 
@@ -13,7 +13,7 @@ exports.main = async function main() {
   try {
     const changelogPath = core.getInput('path') || './CHANGELOG.md'
     const targetVersion = core.getInput('version') || null
-    const validationDepth = parseInt(core.getInput('validation_depth') || '0', 10)
+    const validationLevel = core.getInput('validation_level') || 'none'
 
     if (targetVersion == null) {
       core.warning(
@@ -21,33 +21,44 @@ exports.main = async function main() {
       )
     }
 
+    // Parse data
     core.startGroup('Parse data')
     const rawData = await readFile(changelogPath)
-    const versions = getEntries(rawData).map(parseEntry)
+    const entries = getEntries(rawData).map(parseEntry)
 
-    if (validationDepth != 0) {
-      const releasedVersions = versions.filter(version => version.status != 'unreleased')
-      releasedVersions
-        .reverse()
-        .slice(Math.max(0, releasedVersions.length - validationDepth))
-        .forEach(validateEntry)
-    }
-
-    core.debug(`${versions.length} version logs found`)
+    core.debug(`${entries.length} version logs found`)
     core.endGroup()
 
-    const version = getVersionById(versions, targetVersion)
+    // Validate data
+    core.startGroup('Validate data')
+    if (validationLevel === 'none') {
+      core.info(`Validation level set to 'none'. Skipping validation.`)
+    }
 
-    if (version == null) {
+    if (validationLevel !== 'none') {
+      const validationDepth = parseInt(core.getInput('validation_depth'), 10)
+
+      entries
+        .filter(version => version.status != 'unreleased')
+        .reverse()
+        .slice(Math.max(0, releasedVersions.length - validationDepth))
+        .forEach(validateEntry(validationLevel))
+    }
+    core.endGroup()
+
+    // Return data
+    const entry = getEntryByVersionID(entries, targetVersion)
+
+    if (entry == null) {
       throw new Error(
         `No log entry found${targetVersion != null ? ` for version ${targetVersion}` : ''}`
       )
     }
 
-    core.setOutput('version', version.id)
-    core.setOutput('date', version.date)
-    core.setOutput('status', version.status)
-    core.setOutput('changes', version.text)
+    core.setOutput('version', entry.id)
+    core.setOutput('date', entry.date)
+    core.setOutput('status', entry.status)
+    core.setOutput('changes', entry.text)
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/src/parse-entry-content.js
+++ b/src/parse-entry-content.js
@@ -1,0 +1,10 @@
+exports.parseEntryContent = function (text) {
+  return text
+    .split(/^###\s*/gm)
+    .filter(content => content.replace(/\s+/g, '') != '')
+    .map(content => {
+      const [type, ...items] = content.trim().split(/\r*\n/)
+
+      return { type: type.toLowerCase().trim(), items }
+    })
+}

--- a/src/rules/has-chronological-order.js
+++ b/src/rules/has-chronological-order.js
@@ -1,0 +1,21 @@
+const { lt } = require('semver')
+
+exports.hasChronologicalOrder = function (entries, currentIndex) {
+  const currentEntry = entries[currentIndex]
+  const previousEntry = entries[currentIndex - 1]
+
+  if (previousEntry == null) {
+    return {}
+  }
+
+  if (lt(previousEntry.id, currentEntry.id)) {
+    return {}
+  }
+
+  return {
+    'has-chronological-order': {
+      previous: previousEntry.id,
+      current: currentEntry.id,
+    },
+  }
+}

--- a/src/rules/has-chronological-order.js
+++ b/src/rules/has-chronological-order.js
@@ -1,10 +1,14 @@
-const { lt } = require('semver')
+const { lt, valid } = require('semver')
 
 exports.hasChronologicalOrder = function (entries, currentIndex) {
   const currentEntry = entries[currentIndex]
   const previousEntry = entries[currentIndex - 1]
 
   if (previousEntry == null) {
+    return {}
+  }
+
+  if (!valid(previousEntry.id) || !valid(currentEntry.id)) {
     return {}
   }
 

--- a/src/rules/has-correct-sections.js
+++ b/src/rules/has-correct-sections.js
@@ -1,0 +1,45 @@
+const { diff } = require('semver')
+
+const { parseEntryContent } = require('../parse-entry-content')
+
+exports.hasCorrectSections = function (entries, currentIndex) {
+  const currentEntry = entries[currentIndex]
+  const previousEntry = entries[currentIndex - 1]
+
+  if (previousEntry == null) {
+    return {}
+  }
+
+  const entryTypes = parseEntryContent(currentEntry.changes || currentEntry.text).map(
+    change => change.type
+  )
+  const allowedTypes = getAllowedTypes(previousEntry.id, currentEntry.id)
+
+  if (entryTypes.some(type => allowedTypes.indexOf(type) === -1)) {
+    // Validates that only certain allowed types are in the change set
+    return {
+      'has-correct-sections': {
+        entryID: currentEntry.id,
+        types: allowedTypes,
+      },
+    }
+  }
+
+  return {}
+}
+
+function getAllowedTypes(v1, v2) {
+  const versionDiff = diff(v1, v2)
+
+  switch (versionDiff) {
+    case 'prerelease':
+    case 'prepatch':
+    case 'patch':
+      return ['fixed', 'security']
+    case 'minor':
+    case 'preminor':
+      return ['added', 'changed', 'deprecated', 'fixed', 'security']
+    default:
+      return ['added', 'removed', 'changed', 'deprecated', 'fixed', 'security']
+  }
+}

--- a/src/rules/has-correct-sections.js
+++ b/src/rules/has-correct-sections.js
@@ -1,4 +1,4 @@
-const { diff } = require('semver')
+const { diff, valid } = require('semver')
 
 const { parseEntryContent } = require('../parse-entry-content')
 
@@ -7,6 +7,10 @@ exports.hasCorrectSections = function (entries, currentIndex) {
   const previousEntry = entries[currentIndex - 1]
 
   if (previousEntry == null) {
+    return {}
+  }
+
+  if (!valid(previousEntry.id) || !valid(currentEntry.id)) {
     return {}
   }
 

--- a/src/rules/has-correct-sections.test.js
+++ b/src/rules/has-correct-sections.test.js
@@ -1,0 +1,52 @@
+const { hasCorrectSections } = require('./has-correct-sections')
+
+const entryDescriptionMajor = `
+### Added
+- New attribute isOrdered on TextFieldList. Basicaly, <ol> becomes <ul> when not ordered.
+- It is possible to change the row count of the TextField in TextFieldList.
+- New attribute maxFieldCount on TextFieldList. It hides the add button when the value of maxFieldCount is reached.
+- New DatePickerField component to display a date input.
+- New attribute isSmall on TextField to display a smaller version of he TextField.
+
+### Removed
+- Legacy DatePicker library.
+
+### Changed
+- All form components can be updated using the value attribute.
+- **BREACKING CHANGES** The default behavior of TextFieldList is to be "not ordered".
+  You'll have to add the new isOrdered attribute on your existing components.
+- FormErrors become FormErrorMessages.
+- FormErrorMessages try to translate the error key automatically.
+- ThemeProvider doesn't loads the font anymore. We created a more generic component (UIKitInitializer) that'll do it.
+- FormErrorMessages filter error that are equal to false
+- If an error is equal to en object instead of true, the object is passed to the translator as variables by FormErrorMessages.
+- RadioButton and CheckboxButton support other type than string for their children attribute.
+
+### Fixed
+- Update types to allow no theme data into ThemeProvider.
+- **SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.
+`
+
+test('added section in patch release should throw error', () => {
+  const output = hasCorrectSections(
+    [
+      { id: '1.0.0', changes: entryDescriptionMajor },
+      { id: '1.0.1', changes: entryDescriptionMajor },
+    ],
+    1
+  )
+
+  expect(output).toBeTruthy()
+})
+
+test('removed section in minor release should throw error', () => {
+  const output = hasCorrectSections(
+    [
+      { id: '1.0.0', changes: entryDescriptionMajor },
+      { id: '1.1.0', changes: entryDescriptionMajor },
+    ],
+    1
+  )
+
+  expect(output['has-correct-sections']).toBeTruthy()
+})

--- a/src/rules/has-sections.js
+++ b/src/rules/has-sections.js
@@ -1,0 +1,21 @@
+const { parseEntryContent } = require('../parse-entry-content')
+
+exports.hasSections = function (entry) {
+  const changes = parseEntryContent(entry.changes || entry.text)
+
+  for (const change of changes) {
+    if (change.items.length > 0) {
+      // Validate that there are changes listed under each section
+      continue
+    }
+
+    return {
+      'has-section': {
+        type: change.type,
+        entryID: entry.id,
+      },
+    }
+  }
+
+  return {}
+}

--- a/src/rules/has-sections.test.js
+++ b/src/rules/has-sections.test.js
@@ -1,0 +1,18 @@
+const { hasSections } = require('./has-sections')
+
+test('no listed changes under the heading', () => {
+  const output = hasSections({ id: '1.0.0', changes: '### Added\r\n' })
+
+  expect(output['has-section']).toBeTruthy()
+})
+
+test('no listed changes under the heading', () => {
+  const output = hasSections({
+    id: '1.0.0',
+    changes: `### Fixed
+  - Update types to allow no theme data into ThemeProvider.
+  - **SECURITY** The list components don't use the nth-child CSS attributes in favor of nth-of-type.`,
+  })
+
+  expect(output['has-section']).toBeFalsy()
+})

--- a/src/rules/is-semver.js
+++ b/src/rules/is-semver.js
@@ -1,0 +1,11 @@
+const { valid } = require('semver')
+
+exports.isSemVer = function (entry) {
+  if (valid(entry.id)) {
+    return {}
+  }
+
+  return {
+    'is-semver': true,
+  }
+}

--- a/src/rules/is-semver.test.js
+++ b/src/rules/is-semver.test.js
@@ -1,0 +1,13 @@
+const { isSemVer } = require('./is-semver')
+
+test('throw error on version that is not semantic', () => {
+  const output = isSemVer({ id: 'a.b.c' })
+
+  expect(output['is-semver']).toBeTruthy()
+})
+
+test('throw error on version that is not semantic', () => {
+  const output = isSemVer({ id: '2.0.0' })
+
+  expect(output['is-semver']).toBeFalsy()
+})

--- a/src/validate-entry.test.js
+++ b/src/validate-entry.test.js
@@ -53,7 +53,7 @@ test('validate multiple versions without error', () => {
     { id: '1.1.0', changes: entryDescriptionMinor },
     { id: '2.0.0', changes: entryDescriptionMajor },
   ]
-  const output = () => input.forEach(validateEntry)
+  const output = () => input.forEach(validateEntry('error'))
 
   expect(output).not.toThrow()
 })
@@ -65,18 +65,16 @@ test('throw error on version that is not semantic', () => {
     { id: 'a.b.c', changes: entryDescriptionMinor },
     { id: '2.0.0', changes: entryDescriptionMajor },
   ]
-  const output = () => input.forEach(validateEntry)
+  const output = () => input.forEach(validateEntry('error'))
 
-  expect(output).toThrow(`a.b.c is not a valid semantic version.`)
+  expect(output).toThrow()
 })
 
 test('no listed changes under the heading', () => {
   const input = [{ id: '1.0.0', changes: '### Added\r\n' }]
-  const output = () => input.forEach(validateEntry)
+  const output = () => input.forEach(validateEntry('error'))
 
-  expect(output).toThrow(
-    `The 'added' section under version 1.0.0 does not contain any listed changes under the heading.`
-  )
+  expect(output).toThrow()
 })
 
 test('added section in patch release should throw error', () => {
@@ -84,11 +82,9 @@ test('added section in patch release should throw error', () => {
     { id: '1.0.0', changes: entryDescriptionMajor },
     { id: '1.0.1', changes: entryDescriptionMajor },
   ]
-  const output = () => input.forEach(validateEntry)
+  const output = () => input.forEach(validateEntry('error'))
 
-  expect(output).toThrow(
-    `The sections 'added, removed, changed' under version 1.0.1 are not allowed in a patch release type.`
-  )
+  expect(output).toThrow()
 })
 
 test('removed section in minor release should throw error', () => {
@@ -96,18 +92,14 @@ test('removed section in minor release should throw error', () => {
     { id: '1.0.0', changes: entryDescriptionMajor },
     { id: '1.1.0', changes: entryDescriptionMajor },
   ]
-  const output = () => input.forEach(validateEntry)
+  const output = () => input.forEach(validateEntry('error'))
 
-  expect(output).toThrow(
-    `The section 'removed' under version 1.1.0 is not allowed in a minor release type.`
-  )
+  expect(output).toThrow()
 })
 
 test('an unknown section always throws an error', () => {
   const input = [{ id: '1.0.0', changes: '### Bugfixes\r\n' }]
-  const output = () => input.forEach(validateEntry)
+  const output = () => input.forEach(validateEntry('error'))
 
-  expect(output).toThrow(
-    `The 'bugfixes' section under version 1.0.0 does not contain any listed changes under the heading.`
-  )
+  expect(output).toThrow()
 })

--- a/src/validate-entry.test.js
+++ b/src/validate-entry.test.js
@@ -70,11 +70,30 @@ test('throw error on version that is not semantic', () => {
   expect(output).toThrow()
 })
 
+test('not throw error on version that is not semantic [warn]', () => {
+  const input = [
+    { id: '1.0.0', changes: entryDescriptionMajor },
+    { id: '1.0.1', changes: entryDescriptionPatch },
+    { id: 'a.b.c', changes: entryDescriptionMinor },
+    { id: '2.0.0', changes: entryDescriptionMajor },
+  ]
+  const output = () => input.forEach(validateEntry('warn'))
+
+  expect(output).not.toThrow()
+})
+
 test('no listed changes under the heading', () => {
   const input = [{ id: '1.0.0', changes: '### Added\r\n' }]
   const output = () => input.forEach(validateEntry('error'))
 
   expect(output).toThrow()
+})
+
+test('not throw error when no listed changes under the heading [warn]', () => {
+  const input = [{ id: '1.0.0', changes: '### Added\r\n' }]
+  const output = () => input.forEach(validateEntry('warn'))
+
+  expect(output).not.toThrow()
 })
 
 test('added section in patch release should throw error', () => {
@@ -87,6 +106,16 @@ test('added section in patch release should throw error', () => {
   expect(output).toThrow()
 })
 
+test('added section in patch release should not throw error [warn]', () => {
+  const input = [
+    { id: '1.0.0', changes: entryDescriptionMajor },
+    { id: '1.0.1', changes: entryDescriptionMajor },
+  ]
+  const output = () => input.forEach(validateEntry('warn'))
+
+  expect(output).not.toThrow()
+})
+
 test('removed section in minor release should throw error', () => {
   const input = [
     { id: '1.0.0', changes: entryDescriptionMajor },
@@ -97,9 +126,26 @@ test('removed section in minor release should throw error', () => {
   expect(output).toThrow()
 })
 
+test('removed section in minor release should throw not error [warn]', () => {
+  const input = [
+    { id: '1.0.0', changes: entryDescriptionMajor },
+    { id: '1.1.0', changes: entryDescriptionMajor },
+  ]
+  const output = () => input.forEach(validateEntry('warn'))
+
+  expect(output).not.toThrow()
+})
+
 test('an unknown section always throws an error', () => {
   const input = [{ id: '1.0.0', changes: '### Bugfixes\r\n' }]
   const output = () => input.forEach(validateEntry('error'))
 
   expect(output).toThrow()
+})
+
+test('an unknown section never throws an error [warn]', () => {
+  const input = [{ id: '1.0.0', changes: '### Bugfixes\r\n' }]
+  const output = () => input.forEach(validateEntry('warn'))
+
+  expect(output).not.toThrow()
 })


### PR DESCRIPTION
This PR refactors how the validation system works.

It is now possible to break (or not) the build on validation errors. Before, it would have always been breaking the build.

The feature uses two arguments:
- `validation_level`: can be 'none', 'warn', 'error'. Defaults to 'none' which deactivate the validation step
- `validation_depth`: can be any number of entry to validate. Defaults to `10`
