### PR TITLE
Make 'prerelease' check less strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow more section types into prerelease versions. #67
+
 ## [2.1.1] - 2022-07-03
 
 ### Fixed

--- a/dist/index.js
+++ b/dist/index.js
@@ -3096,13 +3096,14 @@ function getAllowedTypes(v1, v2) {
   const versionDiff = diff(v1, v2)
 
   switch (versionDiff) {
-    case 'prerelease':
     case 'prepatch':
     case 'patch':
       return ['fixed', 'security']
     case 'minor':
     case 'preminor':
       return ['added', 'changed', 'deprecated', 'fixed', 'security']
+    case 'premajor':
+    case 'major':
     default:
       return ['added', 'removed', 'changed', 'deprecated', 'fixed', 'security']
   }

--- a/src/rules/has-correct-sections.js
+++ b/src/rules/has-correct-sections.js
@@ -36,13 +36,14 @@ function getAllowedTypes(v1, v2) {
   const versionDiff = diff(v1, v2)
 
   switch (versionDiff) {
-    case 'prerelease':
     case 'prepatch':
     case 'patch':
       return ['fixed', 'security']
     case 'minor':
     case 'preminor':
       return ['added', 'changed', 'deprecated', 'fixed', 'security']
+    case 'premajor':
+    case 'major':
     default:
       return ['added', 'removed', 'changed', 'deprecated', 'fixed', 'security']
   }


### PR DESCRIPTION
Avoid treating prerelease as a prepatch.

Closes #67 