### PR TITLE
dependencies: bump node to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,5 +29,5 @@ outputs:
   changes:
     description: 'Description text of the log entry found'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Node v16 is deprecated, bump to v20.