### PR TITLE
Get rid of the `set-output` command, deprecated since long ago

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
       - name: Get version from tag
         id: tag_name
         run: |
-          echo ::set-output name=current_version::${GITHUB_REF#refs/tags/v}
+          echo "current_version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
         shell: bash
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Ref.: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

BTW, I'm not sure about when having that trailing "v" in the bash removal is correct or no (in my case we want to keep it), but I've left it as is right now, just changing the command to avoid the the deprecation annotation.

Ciao :-)