### PR TITLE
runtime deps, dist drift check, doc refresh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,13 @@ jobs:
           node-version: 24
       - run: npm ci
       - run: npm test
+      - name: Verify dist/ is up to date
+        run: |
+          npm run build
+          if ! git diff --exit-code --stat dist/; then
+            echo "::error::dist/ is out of sync with src/. Run 'npm run build' and commit the result." >&2
+            exit 1
+          fi
 
   # test action works running from the graph
   e2e:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use Node 24 as the action runtime.
+
+### Fixed
+
+- Declare `semver` as a runtime dependency instead of a dev dependency.
+- Stop dumping the full CHANGELOG content to debug logs when parsing entries and links.
+
 ## [2.2.3] - 2024-03-10
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ This file is a set of guilines for contributing to *Changelog Reader Action* pro
 * [Did you fix whitespace, format code, or make a purely cosmetic patch?](#did-you-fix-whitespace-format-code-or-make-a-purely-cosmetic-patch)
 * [Do you intend to add a new feature or change an existing one?](#do-you-intend-to-add-a-new-feature-or-change-an-existing-one)
 * [Do you have questions about the source code?](#do-you-have-questions-about-the-source-code)
-* [Do you want to contribute to the Changelog Reader Action documentation?](#do-you-want-to-contribute-to-the-Configfile-documentation)
+* [Do you want to contribute to the Changelog Reader Action documentation?](#do-you-want-to-contribute-to-the-changelog-reader-action-documentation)
 
 [Styleguides](#styleguides)
 
@@ -56,9 +56,9 @@ This file is a set of guilines for contributing to *Changelog Reader Action* pro
 
 ### Do you have questions about the source code?
 
-* Ask any question about how to use Configfile in the [forum category][Forum] or on [Stack Overflow](https://stackoverflow.com).
+* Ask any question about how to use Changelog Reader Action in the [forum category][Forum] or on [Stack Overflow](https://stackoverflow.com).
 
-### Do you want to contribute to the Configfile documentation?
+### Do you want to contribute to the Changelog Reader Action documentation?
 
 Documentation file are stored in the project source code.
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -8,7 +8,11 @@
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -21,7 +25,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -83,13 +87,13 @@ class Command {
     }
 }
 function escapeData(s) {
-    return utils_1.toCommandValue(s)
+    return (0, utils_1.toCommandValue)(s)
         .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A');
 }
 function escapeProperty(s) {
-    return utils_1.toCommandValue(s)
+    return (0, utils_1.toCommandValue)(s)
         .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A')
@@ -107,7 +111,11 @@ function escapeProperty(s) {
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -120,7 +128,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -134,7 +142,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
+exports.platform = exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = exports.markdownSummary = exports.summary = exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
 const command_1 = __nccwpck_require__(4914);
 const file_command_1 = __nccwpck_require__(4753);
 const utils_1 = __nccwpck_require__(302);
@@ -154,7 +162,7 @@ var ExitCode;
      * A code indicating that the action was a failure
      */
     ExitCode[ExitCode["Failure"] = 1] = "Failure";
-})(ExitCode = exports.ExitCode || (exports.ExitCode = {}));
+})(ExitCode || (exports.ExitCode = ExitCode = {}));
 //-----------------------------------------------------------------------
 // Variables
 //-----------------------------------------------------------------------
@@ -165,13 +173,13 @@ var ExitCode;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function exportVariable(name, val) {
-    const convertedVal = utils_1.toCommandValue(val);
+    const convertedVal = (0, utils_1.toCommandValue)(val);
     process.env[name] = convertedVal;
     const filePath = process.env['GITHUB_ENV'] || '';
     if (filePath) {
-        return file_command_1.issueFileCommand('ENV', file_command_1.prepareKeyValueMessage(name, val));
+        return (0, file_command_1.issueFileCommand)('ENV', (0, file_command_1.prepareKeyValueMessage)(name, val));
     }
-    command_1.issueCommand('set-env', { name }, convertedVal);
+    (0, command_1.issueCommand)('set-env', { name }, convertedVal);
 }
 exports.exportVariable = exportVariable;
 /**
@@ -179,7 +187,7 @@ exports.exportVariable = exportVariable;
  * @param secret value of the secret
  */
 function setSecret(secret) {
-    command_1.issueCommand('add-mask', {}, secret);
+    (0, command_1.issueCommand)('add-mask', {}, secret);
 }
 exports.setSecret = setSecret;
 /**
@@ -189,10 +197,10 @@ exports.setSecret = setSecret;
 function addPath(inputPath) {
     const filePath = process.env['GITHUB_PATH'] || '';
     if (filePath) {
-        file_command_1.issueFileCommand('PATH', inputPath);
+        (0, file_command_1.issueFileCommand)('PATH', inputPath);
     }
     else {
-        command_1.issueCommand('add-path', {}, inputPath);
+        (0, command_1.issueCommand)('add-path', {}, inputPath);
     }
     process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
 }
@@ -267,10 +275,10 @@ exports.getBooleanInput = getBooleanInput;
 function setOutput(name, value) {
     const filePath = process.env['GITHUB_OUTPUT'] || '';
     if (filePath) {
-        return file_command_1.issueFileCommand('OUTPUT', file_command_1.prepareKeyValueMessage(name, value));
+        return (0, file_command_1.issueFileCommand)('OUTPUT', (0, file_command_1.prepareKeyValueMessage)(name, value));
     }
     process.stdout.write(os.EOL);
-    command_1.issueCommand('set-output', { name }, utils_1.toCommandValue(value));
+    (0, command_1.issueCommand)('set-output', { name }, (0, utils_1.toCommandValue)(value));
 }
 exports.setOutput = setOutput;
 /**
@@ -279,7 +287,7 @@ exports.setOutput = setOutput;
  *
  */
 function setCommandEcho(enabled) {
-    command_1.issue('echo', enabled ? 'on' : 'off');
+    (0, command_1.issue)('echo', enabled ? 'on' : 'off');
 }
 exports.setCommandEcho = setCommandEcho;
 //-----------------------------------------------------------------------
@@ -310,7 +318,7 @@ exports.isDebug = isDebug;
  * @param message debug message
  */
 function debug(message) {
-    command_1.issueCommand('debug', {}, message);
+    (0, command_1.issueCommand)('debug', {}, message);
 }
 exports.debug = debug;
 /**
@@ -319,7 +327,7 @@ exports.debug = debug;
  * @param properties optional properties to add to the annotation.
  */
 function error(message, properties = {}) {
-    command_1.issueCommand('error', utils_1.toCommandProperties(properties), message instanceof Error ? message.toString() : message);
+    (0, command_1.issueCommand)('error', (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
 }
 exports.error = error;
 /**
@@ -328,7 +336,7 @@ exports.error = error;
  * @param properties optional properties to add to the annotation.
  */
 function warning(message, properties = {}) {
-    command_1.issueCommand('warning', utils_1.toCommandProperties(properties), message instanceof Error ? message.toString() : message);
+    (0, command_1.issueCommand)('warning', (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
 }
 exports.warning = warning;
 /**
@@ -337,7 +345,7 @@ exports.warning = warning;
  * @param properties optional properties to add to the annotation.
  */
 function notice(message, properties = {}) {
-    command_1.issueCommand('notice', utils_1.toCommandProperties(properties), message instanceof Error ? message.toString() : message);
+    (0, command_1.issueCommand)('notice', (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
 }
 exports.notice = notice;
 /**
@@ -356,14 +364,14 @@ exports.info = info;
  * @param name The name of the output group
  */
 function startGroup(name) {
-    command_1.issue('group', name);
+    (0, command_1.issue)('group', name);
 }
 exports.startGroup = startGroup;
 /**
  * End an output group.
  */
 function endGroup() {
-    command_1.issue('endgroup');
+    (0, command_1.issue)('endgroup');
 }
 exports.endGroup = endGroup;
 /**
@@ -401,9 +409,9 @@ exports.group = group;
 function saveState(name, value) {
     const filePath = process.env['GITHUB_STATE'] || '';
     if (filePath) {
-        return file_command_1.issueFileCommand('STATE', file_command_1.prepareKeyValueMessage(name, value));
+        return (0, file_command_1.issueFileCommand)('STATE', (0, file_command_1.prepareKeyValueMessage)(name, value));
     }
-    command_1.issueCommand('save-state', { name }, utils_1.toCommandValue(value));
+    (0, command_1.issueCommand)('save-state', { name }, (0, utils_1.toCommandValue)(value));
 }
 exports.saveState = saveState;
 /**
@@ -439,6 +447,10 @@ var path_utils_1 = __nccwpck_require__(1976);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
+/**
+ * Platform utilities exports
+ */
+exports.platform = __importStar(__nccwpck_require__(8968));
 //# sourceMappingURL=core.js.map
 
 /***/ }),
@@ -451,7 +463,11 @@ Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: funct
 // For internal use, subject to change.
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -464,7 +480,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -472,9 +488,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
+const crypto = __importStar(__nccwpck_require__(6982));
 const fs = __importStar(__nccwpck_require__(9896));
 const os = __importStar(__nccwpck_require__(857));
-const uuid_1 = __nccwpck_require__(2048);
 const utils_1 = __nccwpck_require__(302);
 function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -484,14 +500,14 @@ function issueFileCommand(command, message) {
     if (!fs.existsSync(filePath)) {
         throw new Error(`Missing file at path: ${filePath}`);
     }
-    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
+    fs.appendFileSync(filePath, `${(0, utils_1.toCommandValue)(message)}${os.EOL}`, {
         encoding: 'utf8'
     });
 }
 exports.issueFileCommand = issueFileCommand;
 function prepareKeyValueMessage(key, value) {
-    const delimiter = `ghadelimiter_${uuid_1.v4()}`;
-    const convertedValue = utils_1.toCommandValue(value);
+    const delimiter = `ghadelimiter_${crypto.randomUUID()}`;
+    const convertedValue = (0, utils_1.toCommandValue)(value);
     // These should realistically never happen, but just in case someone finds a
     // way to exploit uuid generation let's not allow keys or values that contain
     // the delimiter.
@@ -576,9 +592,9 @@ class OidcClient {
                     const encodedAudience = encodeURIComponent(audience);
                     id_token_url = `${id_token_url}&audience=${encodedAudience}`;
                 }
-                core_1.debug(`ID token url is ${id_token_url}`);
+                (0, core_1.debug)(`ID token url is ${id_token_url}`);
                 const id_token = yield OidcClient.getCall(id_token_url);
-                core_1.setSecret(id_token);
+                (0, core_1.setSecret)(id_token);
                 return id_token;
             }
             catch (error) {
@@ -599,7 +615,11 @@ exports.OidcClient = OidcClient;
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -612,7 +632,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -654,6 +674,107 @@ function toPlatformPath(pth) {
 }
 exports.toPlatformPath = toPlatformPath;
 //# sourceMappingURL=path-utils.js.map
+
+/***/ }),
+
+/***/ 8968:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getDetails = exports.isLinux = exports.isMacOS = exports.isWindows = exports.arch = exports.platform = void 0;
+const os_1 = __importDefault(__nccwpck_require__(857));
+const exec = __importStar(__nccwpck_require__(5236));
+const getWindowsInfo = () => __awaiter(void 0, void 0, void 0, function* () {
+    const { stdout: version } = yield exec.getExecOutput('powershell -command "(Get-CimInstance -ClassName Win32_OperatingSystem).Version"', undefined, {
+        silent: true
+    });
+    const { stdout: name } = yield exec.getExecOutput('powershell -command "(Get-CimInstance -ClassName Win32_OperatingSystem).Caption"', undefined, {
+        silent: true
+    });
+    return {
+        name: name.trim(),
+        version: version.trim()
+    };
+});
+const getMacOsInfo = () => __awaiter(void 0, void 0, void 0, function* () {
+    var _a, _b, _c, _d;
+    const { stdout } = yield exec.getExecOutput('sw_vers', undefined, {
+        silent: true
+    });
+    const version = (_b = (_a = stdout.match(/ProductVersion:\s*(.+)/)) === null || _a === void 0 ? void 0 : _a[1]) !== null && _b !== void 0 ? _b : '';
+    const name = (_d = (_c = stdout.match(/ProductName:\s*(.+)/)) === null || _c === void 0 ? void 0 : _c[1]) !== null && _d !== void 0 ? _d : '';
+    return {
+        name,
+        version
+    };
+});
+const getLinuxInfo = () => __awaiter(void 0, void 0, void 0, function* () {
+    const { stdout } = yield exec.getExecOutput('lsb_release', ['-i', '-r', '-s'], {
+        silent: true
+    });
+    const [name, version] = stdout.trim().split('\n');
+    return {
+        name,
+        version
+    };
+});
+exports.platform = os_1.default.platform();
+exports.arch = os_1.default.arch();
+exports.isWindows = exports.platform === 'win32';
+exports.isMacOS = exports.platform === 'darwin';
+exports.isLinux = exports.platform === 'linux';
+function getDetails() {
+    return __awaiter(this, void 0, void 0, function* () {
+        return Object.assign(Object.assign({}, (yield (exports.isWindows
+            ? getWindowsInfo()
+            : exports.isMacOS
+                ? getMacOsInfo()
+                : getLinuxInfo()))), { platform: exports.platform,
+            arch: exports.arch,
+            isWindows: exports.isWindows,
+            isMacOS: exports.isMacOS,
+            isLinux: exports.isLinux });
+    });
+}
+exports.getDetails = getDetails;
+//# sourceMappingURL=platform.js.map
 
 /***/ }),
 
@@ -991,6 +1112,741 @@ function toCommandProperties(annotationProperties) {
 }
 exports.toCommandProperties = toCommandProperties;
 //# sourceMappingURL=utils.js.map
+
+/***/ }),
+
+/***/ 5236:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getExecOutput = exports.exec = void 0;
+const string_decoder_1 = __nccwpck_require__(3193);
+const tr = __importStar(__nccwpck_require__(6665));
+/**
+ * Exec a command.
+ * Output will be streamed to the live console.
+ * Returns promise with return code
+ *
+ * @param     commandLine        command to execute (can include additional args). Must be correctly escaped.
+ * @param     args               optional arguments for tool. Escaping is handled by the lib.
+ * @param     options            optional exec options.  See ExecOptions
+ * @returns   Promise<number>    exit code
+ */
+function exec(commandLine, args, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const commandArgs = tr.argStringToArray(commandLine);
+        if (commandArgs.length === 0) {
+            throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
+        }
+        // Path to tool to execute should be first arg
+        const toolPath = commandArgs[0];
+        args = commandArgs.slice(1).concat(args || []);
+        const runner = new tr.ToolRunner(toolPath, args, options);
+        return runner.exec();
+    });
+}
+exports.exec = exec;
+/**
+ * Exec a command and get the output.
+ * Output will be streamed to the live console.
+ * Returns promise with the exit code and collected stdout and stderr
+ *
+ * @param     commandLine           command to execute (can include additional args). Must be correctly escaped.
+ * @param     args                  optional arguments for tool. Escaping is handled by the lib.
+ * @param     options               optional exec options.  See ExecOptions
+ * @returns   Promise<ExecOutput>   exit code, stdout, and stderr
+ */
+function getExecOutput(commandLine, args, options) {
+    var _a, _b;
+    return __awaiter(this, void 0, void 0, function* () {
+        let stdout = '';
+        let stderr = '';
+        //Using string decoder covers the case where a mult-byte character is split
+        const stdoutDecoder = new string_decoder_1.StringDecoder('utf8');
+        const stderrDecoder = new string_decoder_1.StringDecoder('utf8');
+        const originalStdoutListener = (_a = options === null || options === void 0 ? void 0 : options.listeners) === null || _a === void 0 ? void 0 : _a.stdout;
+        const originalStdErrListener = (_b = options === null || options === void 0 ? void 0 : options.listeners) === null || _b === void 0 ? void 0 : _b.stderr;
+        const stdErrListener = (data) => {
+            stderr += stderrDecoder.write(data);
+            if (originalStdErrListener) {
+                originalStdErrListener(data);
+            }
+        };
+        const stdOutListener = (data) => {
+            stdout += stdoutDecoder.write(data);
+            if (originalStdoutListener) {
+                originalStdoutListener(data);
+            }
+        };
+        const listeners = Object.assign(Object.assign({}, options === null || options === void 0 ? void 0 : options.listeners), { stdout: stdOutListener, stderr: stdErrListener });
+        const exitCode = yield exec(commandLine, args, Object.assign(Object.assign({}, options), { listeners }));
+        //flush any remaining characters
+        stdout += stdoutDecoder.end();
+        stderr += stderrDecoder.end();
+        return {
+            exitCode,
+            stdout,
+            stderr
+        };
+    });
+}
+exports.getExecOutput = getExecOutput;
+//# sourceMappingURL=exec.js.map
+
+/***/ }),
+
+/***/ 6665:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.argStringToArray = exports.ToolRunner = void 0;
+const os = __importStar(__nccwpck_require__(857));
+const events = __importStar(__nccwpck_require__(4434));
+const child = __importStar(__nccwpck_require__(5317));
+const path = __importStar(__nccwpck_require__(6928));
+const io = __importStar(__nccwpck_require__(4994));
+const ioUtil = __importStar(__nccwpck_require__(5207));
+const timers_1 = __nccwpck_require__(3557);
+/* eslint-disable @typescript-eslint/unbound-method */
+const IS_WINDOWS = process.platform === 'win32';
+/*
+ * Class for running command line tools. Handles quoting and arg parsing in a platform agnostic way.
+ */
+class ToolRunner extends events.EventEmitter {
+    constructor(toolPath, args, options) {
+        super();
+        if (!toolPath) {
+            throw new Error("Parameter 'toolPath' cannot be null or empty.");
+        }
+        this.toolPath = toolPath;
+        this.args = args || [];
+        this.options = options || {};
+    }
+    _debug(message) {
+        if (this.options.listeners && this.options.listeners.debug) {
+            this.options.listeners.debug(message);
+        }
+    }
+    _getCommandString(options, noPrefix) {
+        const toolPath = this._getSpawnFileName();
+        const args = this._getSpawnArgs(options);
+        let cmd = noPrefix ? '' : '[command]'; // omit prefix when piped to a second tool
+        if (IS_WINDOWS) {
+            // Windows + cmd file
+            if (this._isCmdFile()) {
+                cmd += toolPath;
+                for (const a of args) {
+                    cmd += ` ${a}`;
+                }
+            }
+            // Windows + verbatim
+            else if (options.windowsVerbatimArguments) {
+                cmd += `"${toolPath}"`;
+                for (const a of args) {
+                    cmd += ` ${a}`;
+                }
+            }
+            // Windows (regular)
+            else {
+                cmd += this._windowsQuoteCmdArg(toolPath);
+                for (const a of args) {
+                    cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+                }
+            }
+        }
+        else {
+            // OSX/Linux - this can likely be improved with some form of quoting.
+            // creating processes on Unix is fundamentally different than Windows.
+            // on Unix, execvp() takes an arg array.
+            cmd += toolPath;
+            for (const a of args) {
+                cmd += ` ${a}`;
+            }
+        }
+        return cmd;
+    }
+    _processLineBuffer(data, strBuffer, onLine) {
+        try {
+            let s = strBuffer + data.toString();
+            let n = s.indexOf(os.EOL);
+            while (n > -1) {
+                const line = s.substring(0, n);
+                onLine(line);
+                // the rest of the string ...
+                s = s.substring(n + os.EOL.length);
+                n = s.indexOf(os.EOL);
+            }
+            return s;
+        }
+        catch (err) {
+            // streaming lines to console is best effort.  Don't fail a build.
+            this._debug(`error processing line. Failed with error ${err}`);
+            return '';
+        }
+    }
+    _getSpawnFileName() {
+        if (IS_WINDOWS) {
+            if (this._isCmdFile()) {
+                return process.env['COMSPEC'] || 'cmd.exe';
+            }
+        }
+        return this.toolPath;
+    }
+    _getSpawnArgs(options) {
+        if (IS_WINDOWS) {
+            if (this._isCmdFile()) {
+                let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
+                for (const a of this.args) {
+                    argline += ' ';
+                    argline += options.windowsVerbatimArguments
+                        ? a
+                        : this._windowsQuoteCmdArg(a);
+                }
+                argline += '"';
+                return [argline];
+            }
+        }
+        return this.args;
+    }
+    _endsWith(str, end) {
+        return str.endsWith(end);
+    }
+    _isCmdFile() {
+        const upperToolPath = this.toolPath.toUpperCase();
+        return (this._endsWith(upperToolPath, '.CMD') ||
+            this._endsWith(upperToolPath, '.BAT'));
+    }
+    _windowsQuoteCmdArg(arg) {
+        // for .exe, apply the normal quoting rules that libuv applies
+        if (!this._isCmdFile()) {
+            return this._uvQuoteCmdArg(arg);
+        }
+        // otherwise apply quoting rules specific to the cmd.exe command line parser.
+        // the libuv rules are generic and are not designed specifically for cmd.exe
+        // command line parser.
+        //
+        // for a detailed description of the cmd.exe command line parser, refer to
+        // http://stackoverflow.com/questions/4094699/how-does-the-windows-command-interpreter-cmd-exe-parse-scripts/7970912#7970912
+        // need quotes for empty arg
+        if (!arg) {
+            return '""';
+        }
+        // determine whether the arg needs to be quoted
+        const cmdSpecialChars = [
+            ' ',
+            '\t',
+            '&',
+            '(',
+            ')',
+            '[',
+            ']',
+            '{',
+            '}',
+            '^',
+            '=',
+            ';',
+            '!',
+            "'",
+            '+',
+            ',',
+            '`',
+            '~',
+            '|',
+            '<',
+            '>',
+            '"'
+        ];
+        let needsQuotes = false;
+        for (const char of arg) {
+            if (cmdSpecialChars.some(x => x === char)) {
+                needsQuotes = true;
+                break;
+            }
+        }
+        // short-circuit if quotes not needed
+        if (!needsQuotes) {
+            return arg;
+        }
+        // the following quoting rules are very similar to the rules that by libuv applies.
+        //
+        // 1) wrap the string in quotes
+        //
+        // 2) double-up quotes - i.e. " => ""
+        //
+        //    this is different from the libuv quoting rules. libuv replaces " with \", which unfortunately
+        //    doesn't work well with a cmd.exe command line.
+        //
+        //    note, replacing " with "" also works well if the arg is passed to a downstream .NET console app.
+        //    for example, the command line:
+        //          foo.exe "myarg:""my val"""
+        //    is parsed by a .NET console app into an arg array:
+        //          [ "myarg:\"my val\"" ]
+        //    which is the same end result when applying libuv quoting rules. although the actual
+        //    command line from libuv quoting rules would look like:
+        //          foo.exe "myarg:\"my val\""
+        //
+        // 3) double-up slashes that precede a quote,
+        //    e.g.  hello \world    => "hello \world"
+        //          hello\"world    => "hello\\""world"
+        //          hello\\"world   => "hello\\\\""world"
+        //          hello world\    => "hello world\\"
+        //
+        //    technically this is not required for a cmd.exe command line, or the batch argument parser.
+        //    the reasons for including this as a .cmd quoting rule are:
+        //
+        //    a) this is optimized for the scenario where the argument is passed from the .cmd file to an
+        //       external program. many programs (e.g. .NET console apps) rely on the slash-doubling rule.
+        //
+        //    b) it's what we've been doing previously (by deferring to node default behavior) and we
+        //       haven't heard any complaints about that aspect.
+        //
+        // note, a weakness of the quoting rules chosen here, is that % is not escaped. in fact, % cannot be
+        // escaped when used on the command line directly - even though within a .cmd file % can be escaped
+        // by using %%.
+        //
+        // the saving grace is, on the command line, %var% is left as-is if var is not defined. this contrasts
+        // the line parsing rules within a .cmd file, where if var is not defined it is replaced with nothing.
+        //
+        // one option that was explored was replacing % with ^% - i.e. %var% => ^%var^%. this hack would
+        // often work, since it is unlikely that var^ would exist, and the ^ character is removed when the
+        // variable is used. the problem, however, is that ^ is not removed when %* is used to pass the args
+        // to an external program.
+        //
+        // an unexplored potential solution for the % escaping problem, is to create a wrapper .cmd file.
+        // % can be escaped within a .cmd file.
+        let reverse = '"';
+        let quoteHit = true;
+        for (let i = arg.length; i > 0; i--) {
+            // walk the string in reverse
+            reverse += arg[i - 1];
+            if (quoteHit && arg[i - 1] === '\\') {
+                reverse += '\\'; // double the slash
+            }
+            else if (arg[i - 1] === '"') {
+                quoteHit = true;
+                reverse += '"'; // double the quote
+            }
+            else {
+                quoteHit = false;
+            }
+        }
+        reverse += '"';
+        return reverse
+            .split('')
+            .reverse()
+            .join('');
+    }
+    _uvQuoteCmdArg(arg) {
+        // Tool runner wraps child_process.spawn() and needs to apply the same quoting as
+        // Node in certain cases where the undocumented spawn option windowsVerbatimArguments
+        // is used.
+        //
+        // Since this function is a port of quote_cmd_arg from Node 4.x (technically, lib UV,
+        // see https://github.com/nodejs/node/blob/v4.x/deps/uv/src/win/process.c for details),
+        // pasting copyright notice from Node within this function:
+        //
+        //      Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+        //
+        //      Permission is hereby granted, free of charge, to any person obtaining a copy
+        //      of this software and associated documentation files (the "Software"), to
+        //      deal in the Software without restriction, including without limitation the
+        //      rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+        //      sell copies of the Software, and to permit persons to whom the Software is
+        //      furnished to do so, subject to the following conditions:
+        //
+        //      The above copyright notice and this permission notice shall be included in
+        //      all copies or substantial portions of the Software.
+        //
+        //      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        //      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        //      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        //      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        //      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+        //      FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+        //      IN THE SOFTWARE.
+        if (!arg) {
+            // Need double quotation for empty argument
+            return '""';
+        }
+        if (!arg.includes(' ') && !arg.includes('\t') && !arg.includes('"')) {
+            // No quotation needed
+            return arg;
+        }
+        if (!arg.includes('"') && !arg.includes('\\')) {
+            // No embedded double quotes or backslashes, so I can just wrap
+            // quote marks around the whole thing.
+            return `"${arg}"`;
+        }
+        // Expected input/output:
+        //   input : hello"world
+        //   output: "hello\"world"
+        //   input : hello""world
+        //   output: "hello\"\"world"
+        //   input : hello\world
+        //   output: hello\world
+        //   input : hello\\world
+        //   output: hello\\world
+        //   input : hello\"world
+        //   output: "hello\\\"world"
+        //   input : hello\\"world
+        //   output: "hello\\\\\"world"
+        //   input : hello world\
+        //   output: "hello world\\" - note the comment in libuv actually reads "hello world\"
+        //                             but it appears the comment is wrong, it should be "hello world\\"
+        let reverse = '"';
+        let quoteHit = true;
+        for (let i = arg.length; i > 0; i--) {
+            // walk the string in reverse
+            reverse += arg[i - 1];
+            if (quoteHit && arg[i - 1] === '\\') {
+                reverse += '\\';
+            }
+            else if (arg[i - 1] === '"') {
+                quoteHit = true;
+                reverse += '\\';
+            }
+            else {
+                quoteHit = false;
+            }
+        }
+        reverse += '"';
+        return reverse
+            .split('')
+            .reverse()
+            .join('');
+    }
+    _cloneExecOptions(options) {
+        options = options || {};
+        const result = {
+            cwd: options.cwd || process.cwd(),
+            env: options.env || process.env,
+            silent: options.silent || false,
+            windowsVerbatimArguments: options.windowsVerbatimArguments || false,
+            failOnStdErr: options.failOnStdErr || false,
+            ignoreReturnCode: options.ignoreReturnCode || false,
+            delay: options.delay || 10000
+        };
+        result.outStream = options.outStream || process.stdout;
+        result.errStream = options.errStream || process.stderr;
+        return result;
+    }
+    _getSpawnOptions(options, toolPath) {
+        options = options || {};
+        const result = {};
+        result.cwd = options.cwd;
+        result.env = options.env;
+        result['windowsVerbatimArguments'] =
+            options.windowsVerbatimArguments || this._isCmdFile();
+        if (options.windowsVerbatimArguments) {
+            result.argv0 = `"${toolPath}"`;
+        }
+        return result;
+    }
+    /**
+     * Exec a tool.
+     * Output will be streamed to the live console.
+     * Returns promise with return code
+     *
+     * @param     tool     path to tool to exec
+     * @param     options  optional exec options.  See ExecOptions
+     * @returns   number
+     */
+    exec() {
+        return __awaiter(this, void 0, void 0, function* () {
+            // root the tool path if it is unrooted and contains relative pathing
+            if (!ioUtil.isRooted(this.toolPath) &&
+                (this.toolPath.includes('/') ||
+                    (IS_WINDOWS && this.toolPath.includes('\\')))) {
+                // prefer options.cwd if it is specified, however options.cwd may also need to be rooted
+                this.toolPath = path.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+            }
+            // if the tool is only a file name, then resolve it from the PATH
+            // otherwise verify it exists (add extension on Windows if necessary)
+            this.toolPath = yield io.which(this.toolPath, true);
+            return new Promise((resolve, reject) => __awaiter(this, void 0, void 0, function* () {
+                this._debug(`exec tool: ${this.toolPath}`);
+                this._debug('arguments:');
+                for (const arg of this.args) {
+                    this._debug(`   ${arg}`);
+                }
+                const optionsNonNull = this._cloneExecOptions(this.options);
+                if (!optionsNonNull.silent && optionsNonNull.outStream) {
+                    optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os.EOL);
+                }
+                const state = new ExecState(optionsNonNull, this.toolPath);
+                state.on('debug', (message) => {
+                    this._debug(message);
+                });
+                if (this.options.cwd && !(yield ioUtil.exists(this.options.cwd))) {
+                    return reject(new Error(`The cwd: ${this.options.cwd} does not exist!`));
+                }
+                const fileName = this._getSpawnFileName();
+                const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+                let stdbuffer = '';
+                if (cp.stdout) {
+                    cp.stdout.on('data', (data) => {
+                        if (this.options.listeners && this.options.listeners.stdout) {
+                            this.options.listeners.stdout(data);
+                        }
+                        if (!optionsNonNull.silent && optionsNonNull.outStream) {
+                            optionsNonNull.outStream.write(data);
+                        }
+                        stdbuffer = this._processLineBuffer(data, stdbuffer, (line) => {
+                            if (this.options.listeners && this.options.listeners.stdline) {
+                                this.options.listeners.stdline(line);
+                            }
+                        });
+                    });
+                }
+                let errbuffer = '';
+                if (cp.stderr) {
+                    cp.stderr.on('data', (data) => {
+                        state.processStderr = true;
+                        if (this.options.listeners && this.options.listeners.stderr) {
+                            this.options.listeners.stderr(data);
+                        }
+                        if (!optionsNonNull.silent &&
+                            optionsNonNull.errStream &&
+                            optionsNonNull.outStream) {
+                            const s = optionsNonNull.failOnStdErr
+                                ? optionsNonNull.errStream
+                                : optionsNonNull.outStream;
+                            s.write(data);
+                        }
+                        errbuffer = this._processLineBuffer(data, errbuffer, (line) => {
+                            if (this.options.listeners && this.options.listeners.errline) {
+                                this.options.listeners.errline(line);
+                            }
+                        });
+                    });
+                }
+                cp.on('error', (err) => {
+                    state.processError = err.message;
+                    state.processExited = true;
+                    state.processClosed = true;
+                    state.CheckComplete();
+                });
+                cp.on('exit', (code) => {
+                    state.processExitCode = code;
+                    state.processExited = true;
+                    this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
+                    state.CheckComplete();
+                });
+                cp.on('close', (code) => {
+                    state.processExitCode = code;
+                    state.processExited = true;
+                    state.processClosed = true;
+                    this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
+                    state.CheckComplete();
+                });
+                state.on('done', (error, exitCode) => {
+                    if (stdbuffer.length > 0) {
+                        this.emit('stdline', stdbuffer);
+                    }
+                    if (errbuffer.length > 0) {
+                        this.emit('errline', errbuffer);
+                    }
+                    cp.removeAllListeners();
+                    if (error) {
+                        reject(error);
+                    }
+                    else {
+                        resolve(exitCode);
+                    }
+                });
+                if (this.options.input) {
+                    if (!cp.stdin) {
+                        throw new Error('child process missing stdin');
+                    }
+                    cp.stdin.end(this.options.input);
+                }
+            }));
+        });
+    }
+}
+exports.ToolRunner = ToolRunner;
+/**
+ * Convert an arg string to an array of args. Handles escaping
+ *
+ * @param    argString   string of arguments
+ * @returns  string[]    array of arguments
+ */
+function argStringToArray(argString) {
+    const args = [];
+    let inQuotes = false;
+    let escaped = false;
+    let arg = '';
+    function append(c) {
+        // we only escape double quotes.
+        if (escaped && c !== '"') {
+            arg += '\\';
+        }
+        arg += c;
+        escaped = false;
+    }
+    for (let i = 0; i < argString.length; i++) {
+        const c = argString.charAt(i);
+        if (c === '"') {
+            if (!escaped) {
+                inQuotes = !inQuotes;
+            }
+            else {
+                append(c);
+            }
+            continue;
+        }
+        if (c === '\\' && escaped) {
+            append(c);
+            continue;
+        }
+        if (c === '\\' && inQuotes) {
+            escaped = true;
+            continue;
+        }
+        if (c === ' ' && !inQuotes) {
+            if (arg.length > 0) {
+                args.push(arg);
+                arg = '';
+            }
+            continue;
+        }
+        append(c);
+    }
+    if (arg.length > 0) {
+        args.push(arg.trim());
+    }
+    return args;
+}
+exports.argStringToArray = argStringToArray;
+class ExecState extends events.EventEmitter {
+    constructor(options, toolPath) {
+        super();
+        this.processClosed = false; // tracks whether the process has exited and stdio is closed
+        this.processError = '';
+        this.processExitCode = 0;
+        this.processExited = false; // tracks whether the process has exited
+        this.processStderr = false; // tracks whether stderr was written to
+        this.delay = 10000; // 10 seconds
+        this.done = false;
+        this.timeout = null;
+        if (!toolPath) {
+            throw new Error('toolPath must not be empty');
+        }
+        this.options = options;
+        this.toolPath = toolPath;
+        if (options.delay) {
+            this.delay = options.delay;
+        }
+    }
+    CheckComplete() {
+        if (this.done) {
+            return;
+        }
+        if (this.processClosed) {
+            this._setResult();
+        }
+        else if (this.processExited) {
+            this.timeout = timers_1.setTimeout(ExecState.HandleTimeout, this.delay, this);
+        }
+    }
+    _debug(message) {
+        this.emit('debug', message);
+    }
+    _setResult() {
+        // determine whether there is an error
+        let error;
+        if (this.processExited) {
+            if (this.processError) {
+                error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
+            }
+            else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
+                error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+            }
+            else if (this.processStderr && this.options.failOnStdErr) {
+                error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
+            }
+        }
+        // clear the timeout
+        if (this.timeout) {
+            clearTimeout(this.timeout);
+            this.timeout = null;
+        }
+        this.done = true;
+        this.emit('done', error, this.processExitCode);
+    }
+    static HandleTimeout(state) {
+        if (state.done) {
+            return;
+        }
+        if (!state.processClosed && state.processExited) {
+            const message = `The STDIO streams did not close within ${state.delay /
+                1000} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
+            state._debug(message);
+        }
+        state._setResult();
+    }
+}
+//# sourceMappingURL=toolrunner.js.map
 
 /***/ }),
 
@@ -1759,6 +2615,502 @@ function checkBypass(reqUrl) {
 }
 exports.checkBypass = checkBypass;
 //# sourceMappingURL=proxy.js.map
+
+/***/ }),
+
+/***/ 5207:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var _a;
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
+const fs = __importStar(__nccwpck_require__(9896));
+const path = __importStar(__nccwpck_require__(6928));
+_a = fs.promises
+// export const {open} = 'fs'
+, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
+// export const {open} = 'fs'
+exports.IS_WINDOWS = process.platform === 'win32';
+// See https://github.com/nodejs/node/blob/d0153aee367422d0858105abec186da4dff0a0c5/deps/uv/include/uv/win.h#L691
+exports.UV_FS_O_EXLOCK = 0x10000000;
+exports.READONLY = fs.constants.O_RDONLY;
+function exists(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            yield exports.stat(fsPath);
+        }
+        catch (err) {
+            if (err.code === 'ENOENT') {
+                return false;
+            }
+            throw err;
+        }
+        return true;
+    });
+}
+exports.exists = exists;
+function isDirectory(fsPath, useStat = false) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const stats = useStat ? yield exports.stat(fsPath) : yield exports.lstat(fsPath);
+        return stats.isDirectory();
+    });
+}
+exports.isDirectory = isDirectory;
+/**
+ * On OSX/Linux, true if path starts with '/'. On Windows, true for paths like:
+ * \, \hello, \\hello\share, C:, and C:\hello (and corresponding alternate separator cases).
+ */
+function isRooted(p) {
+    p = normalizeSeparators(p);
+    if (!p) {
+        throw new Error('isRooted() parameter "p" cannot be empty');
+    }
+    if (exports.IS_WINDOWS) {
+        return (p.startsWith('\\') || /^[A-Z]:/i.test(p) // e.g. \ or \hello or \\hello
+        ); // e.g. C: or C:\hello
+    }
+    return p.startsWith('/');
+}
+exports.isRooted = isRooted;
+/**
+ * Best effort attempt to determine whether a file exists and is executable.
+ * @param filePath    file path to check
+ * @param extensions  additional file extensions to try
+ * @return if file exists and is executable, returns the file path. otherwise empty string.
+ */
+function tryGetExecutablePath(filePath, extensions) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let stats = undefined;
+        try {
+            // test file exists
+            stats = yield exports.stat(filePath);
+        }
+        catch (err) {
+            if (err.code !== 'ENOENT') {
+                // eslint-disable-next-line no-console
+                console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+            }
+        }
+        if (stats && stats.isFile()) {
+            if (exports.IS_WINDOWS) {
+                // on Windows, test for valid extension
+                const upperExt = path.extname(filePath).toUpperCase();
+                if (extensions.some(validExt => validExt.toUpperCase() === upperExt)) {
+                    return filePath;
+                }
+            }
+            else {
+                if (isUnixExecutable(stats)) {
+                    return filePath;
+                }
+            }
+        }
+        // try each extension
+        const originalFilePath = filePath;
+        for (const extension of extensions) {
+            filePath = originalFilePath + extension;
+            stats = undefined;
+            try {
+                stats = yield exports.stat(filePath);
+            }
+            catch (err) {
+                if (err.code !== 'ENOENT') {
+                    // eslint-disable-next-line no-console
+                    console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+                }
+            }
+            if (stats && stats.isFile()) {
+                if (exports.IS_WINDOWS) {
+                    // preserve the case of the actual file (since an extension was appended)
+                    try {
+                        const directory = path.dirname(filePath);
+                        const upperName = path.basename(filePath).toUpperCase();
+                        for (const actualName of yield exports.readdir(directory)) {
+                            if (upperName === actualName.toUpperCase()) {
+                                filePath = path.join(directory, actualName);
+                                break;
+                            }
+                        }
+                    }
+                    catch (err) {
+                        // eslint-disable-next-line no-console
+                        console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+                    }
+                    return filePath;
+                }
+                else {
+                    if (isUnixExecutable(stats)) {
+                        return filePath;
+                    }
+                }
+            }
+        }
+        return '';
+    });
+}
+exports.tryGetExecutablePath = tryGetExecutablePath;
+function normalizeSeparators(p) {
+    p = p || '';
+    if (exports.IS_WINDOWS) {
+        // convert slashes on Windows
+        p = p.replace(/\//g, '\\');
+        // remove redundant slashes
+        return p.replace(/\\\\+/g, '\\');
+    }
+    // remove redundant slashes
+    return p.replace(/\/\/+/g, '/');
+}
+// on Mac/Linux, test the execute bit
+//     R   W  X  R  W X R W X
+//   256 128 64 32 16 8 4 2 1
+function isUnixExecutable(stats) {
+    return ((stats.mode & 1) > 0 ||
+        ((stats.mode & 8) > 0 && stats.gid === process.getgid()) ||
+        ((stats.mode & 64) > 0 && stats.uid === process.getuid()));
+}
+// Get the path of cmd.exe in windows
+function getCmdPath() {
+    var _a;
+    return (_a = process.env['COMSPEC']) !== null && _a !== void 0 ? _a : `cmd.exe`;
+}
+exports.getCmdPath = getCmdPath;
+//# sourceMappingURL=io-util.js.map
+
+/***/ }),
+
+/***/ 4994:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
+const assert_1 = __nccwpck_require__(2613);
+const path = __importStar(__nccwpck_require__(6928));
+const ioUtil = __importStar(__nccwpck_require__(5207));
+/**
+ * Copies a file or folder.
+ * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
+ *
+ * @param     source    source path
+ * @param     dest      destination path
+ * @param     options   optional. See CopyOptions.
+ */
+function cp(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { force, recursive, copySourceDirectory } = readCopyOptions(options);
+        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+        // Dest is an existing file, but not forcing
+        if (destStat && destStat.isFile() && !force) {
+            return;
+        }
+        // If dest is an existing directory, should copy inside.
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory
+            ? path.join(dest, path.basename(source))
+            : dest;
+        if (!(yield ioUtil.exists(source))) {
+            throw new Error(`no such file or directory: ${source}`);
+        }
+        const sourceStat = yield ioUtil.stat(source);
+        if (sourceStat.isDirectory()) {
+            if (!recursive) {
+                throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+            }
+            else {
+                yield cpDirRecursive(source, newDest, 0, force);
+            }
+        }
+        else {
+            if (path.relative(source, newDest) === '') {
+                // a file cannot be copied to itself
+                throw new Error(`'${newDest}' and '${source}' are the same file`);
+            }
+            yield copyFile(source, newDest, force);
+        }
+    });
+}
+exports.cp = cp;
+/**
+ * Moves a path.
+ *
+ * @param     source    source path
+ * @param     dest      destination path
+ * @param     options   optional. See MoveOptions.
+ */
+function mv(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (yield ioUtil.exists(dest)) {
+            let destExists = true;
+            if (yield ioUtil.isDirectory(dest)) {
+                // If dest is directory copy src into dest
+                dest = path.join(dest, path.basename(source));
+                destExists = yield ioUtil.exists(dest);
+            }
+            if (destExists) {
+                if (options.force == null || options.force) {
+                    yield rmRF(dest);
+                }
+                else {
+                    throw new Error('Destination already exists');
+                }
+            }
+        }
+        yield mkdirP(path.dirname(dest));
+        yield ioUtil.rename(source, dest);
+    });
+}
+exports.mv = mv;
+/**
+ * Remove a path recursively with force
+ *
+ * @param inputPath path to remove
+ */
+function rmRF(inputPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (ioUtil.IS_WINDOWS) {
+            // Check for invalid characters
+            // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+            if (/[*"<>|]/.test(inputPath)) {
+                throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+            }
+        }
+        try {
+            // note if path does not exist, error is silent
+            yield ioUtil.rm(inputPath, {
+                force: true,
+                maxRetries: 3,
+                recursive: true,
+                retryDelay: 300
+            });
+        }
+        catch (err) {
+            throw new Error(`File was unable to be removed ${err}`);
+        }
+    });
+}
+exports.rmRF = rmRF;
+/**
+ * Make a directory.  Creates the full path with folders in between
+ * Will throw if it fails
+ *
+ * @param   fsPath        path to create
+ * @returns Promise<void>
+ */
+function mkdirP(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        assert_1.ok(fsPath, 'a path argument must be provided');
+        yield ioUtil.mkdir(fsPath, { recursive: true });
+    });
+}
+exports.mkdirP = mkdirP;
+/**
+ * Returns path of a tool had the tool actually been invoked.  Resolves via paths.
+ * If you check and the tool does not exist, it will throw.
+ *
+ * @param     tool              name of the tool
+ * @param     check             whether to check if tool exists
+ * @returns   Promise<string>   path to tool
+ */
+function which(tool, check) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+            throw new Error("parameter 'tool' is required");
+        }
+        // recursive when check=true
+        if (check) {
+            const result = yield which(tool, false);
+            if (!result) {
+                if (ioUtil.IS_WINDOWS) {
+                    throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+                }
+                else {
+                    throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+                }
+            }
+            return result;
+        }
+        const matches = yield findInPath(tool);
+        if (matches && matches.length > 0) {
+            return matches[0];
+        }
+        return '';
+    });
+}
+exports.which = which;
+/**
+ * Returns a list of all occurrences of the given tool on the system path.
+ *
+ * @returns   Promise<string[]>  the paths of the tool
+ */
+function findInPath(tool) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+            throw new Error("parameter 'tool' is required");
+        }
+        // build the list of extensions to try
+        const extensions = [];
+        if (ioUtil.IS_WINDOWS && process.env['PATHEXT']) {
+            for (const extension of process.env['PATHEXT'].split(path.delimiter)) {
+                if (extension) {
+                    extensions.push(extension);
+                }
+            }
+        }
+        // if it's rooted, return it if exists. otherwise return empty.
+        if (ioUtil.isRooted(tool)) {
+            const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
+            if (filePath) {
+                return [filePath];
+            }
+            return [];
+        }
+        // if any path separators, return empty
+        if (tool.includes(path.sep)) {
+            return [];
+        }
+        // build the list of directories
+        //
+        // Note, technically "where" checks the current directory on Windows. From a toolkit perspective,
+        // it feels like we should not do this. Checking the current directory seems like more of a use
+        // case of a shell, and the which() function exposed by the toolkit should strive for consistency
+        // across platforms.
+        const directories = [];
+        if (process.env.PATH) {
+            for (const p of process.env.PATH.split(path.delimiter)) {
+                if (p) {
+                    directories.push(p);
+                }
+            }
+        }
+        // find all matches
+        const matches = [];
+        for (const directory of directories) {
+            const filePath = yield ioUtil.tryGetExecutablePath(path.join(directory, tool), extensions);
+            if (filePath) {
+                matches.push(filePath);
+            }
+        }
+        return matches;
+    });
+}
+exports.findInPath = findInPath;
+function readCopyOptions(options) {
+    const force = options.force == null ? true : options.force;
+    const recursive = Boolean(options.recursive);
+    const copySourceDirectory = options.copySourceDirectory == null
+        ? true
+        : Boolean(options.copySourceDirectory);
+    return { force, recursive, copySourceDirectory };
+}
+function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // Ensure there is not a run away recursive copy
+        if (currentDepth >= 255)
+            return;
+        currentDepth++;
+        yield mkdirP(destDir);
+        const files = yield ioUtil.readdir(sourceDir);
+        for (const fileName of files) {
+            const srcFile = `${sourceDir}/${fileName}`;
+            const destFile = `${destDir}/${fileName}`;
+            const srcFileStat = yield ioUtil.lstat(srcFile);
+            if (srcFileStat.isDirectory()) {
+                // Recurse
+                yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+            }
+            else {
+                yield copyFile(srcFile, destFile, force);
+            }
+        }
+        // Change the mode for the newly created directory
+        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+    });
+}
+// Buffered file copy
+function copyFile(srcFile, destFile, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+            // unlink/re-link it
+            try {
+                yield ioUtil.lstat(destFile);
+                yield ioUtil.unlink(destFile);
+            }
+            catch (e) {
+                // Try to override file permission
+                if (e.code === 'EPERM') {
+                    yield ioUtil.chmod(destFile, '0666');
+                    yield ioUtil.unlink(destFile);
+                }
+                // other errors = it doesn't exist, no work to do
+            }
+            // Copy over symlink
+            const symlinkFull = yield ioUtil.readlink(srcFile);
+            yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? 'junction' : null);
+        }
+        else if (!(yield ioUtil.exists(destFile)) || force) {
+            yield ioUtil.copyFile(srcFile, destFile);
+        }
+    });
+}
+//# sourceMappingURL=io.js.map
 
 /***/ }),
 
@@ -3601,7 +4953,7 @@ const Comparator = __nccwpck_require__(9379)
 const Range = __nccwpck_require__(6782)
 const satisfies = __nccwpck_require__(8011)
 const toComparators = __nccwpck_require__(4750)
-const maxSatisfying = __nccwpck_require__(3193)
+const maxSatisfying = __nccwpck_require__(5574)
 const minSatisfying = __nccwpck_require__(8595)
 const minVersion = __nccwpck_require__(1866)
 const validRange = __nccwpck_require__(4737)
@@ -4032,7 +5384,7 @@ module.exports = ltr
 
 /***/ }),
 
-/***/ 3193:
+/***/ 5574:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const SemVer = __nccwpck_require__(7163)
@@ -4871,652 +6223,6 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 2048:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-Object.defineProperty(exports, "v1", ({
-  enumerable: true,
-  get: function () {
-    return _v.default;
-  }
-}));
-Object.defineProperty(exports, "v3", ({
-  enumerable: true,
-  get: function () {
-    return _v2.default;
-  }
-}));
-Object.defineProperty(exports, "v4", ({
-  enumerable: true,
-  get: function () {
-    return _v3.default;
-  }
-}));
-Object.defineProperty(exports, "v5", ({
-  enumerable: true,
-  get: function () {
-    return _v4.default;
-  }
-}));
-Object.defineProperty(exports, "NIL", ({
-  enumerable: true,
-  get: function () {
-    return _nil.default;
-  }
-}));
-Object.defineProperty(exports, "version", ({
-  enumerable: true,
-  get: function () {
-    return _version.default;
-  }
-}));
-Object.defineProperty(exports, "validate", ({
-  enumerable: true,
-  get: function () {
-    return _validate.default;
-  }
-}));
-Object.defineProperty(exports, "stringify", ({
-  enumerable: true,
-  get: function () {
-    return _stringify.default;
-  }
-}));
-Object.defineProperty(exports, "parse", ({
-  enumerable: true,
-  get: function () {
-    return _parse.default;
-  }
-}));
-
-var _v = _interopRequireDefault(__nccwpck_require__(6415));
-
-var _v2 = _interopRequireDefault(__nccwpck_require__(1697));
-
-var _v3 = _interopRequireDefault(__nccwpck_require__(4676));
-
-var _v4 = _interopRequireDefault(__nccwpck_require__(9771));
-
-var _nil = _interopRequireDefault(__nccwpck_require__(7723));
-
-var _version = _interopRequireDefault(__nccwpck_require__(5868));
-
-var _validate = _interopRequireDefault(__nccwpck_require__(6200));
-
-var _stringify = _interopRequireDefault(__nccwpck_require__(7597));
-
-var _parse = _interopRequireDefault(__nccwpck_require__(7267));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-/***/ }),
-
-/***/ 216:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = void 0;
-
-var _crypto = _interopRequireDefault(__nccwpck_require__(6982));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function md5(bytes) {
-  if (Array.isArray(bytes)) {
-    bytes = Buffer.from(bytes);
-  } else if (typeof bytes === 'string') {
-    bytes = Buffer.from(bytes, 'utf8');
-  }
-
-  return _crypto.default.createHash('md5').update(bytes).digest();
-}
-
-var _default = md5;
-exports["default"] = _default;
-
-/***/ }),
-
-/***/ 7723:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = void 0;
-var _default = '00000000-0000-0000-0000-000000000000';
-exports["default"] = _default;
-
-/***/ }),
-
-/***/ 7267:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = void 0;
-
-var _validate = _interopRequireDefault(__nccwpck_require__(6200));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function parse(uuid) {
-  if (!(0, _validate.default)(uuid)) {
-    throw TypeError('Invalid UUID');
-  }
-
-  let v;
-  const arr = new Uint8Array(16); // Parse ########-....-....-....-............
-
-  arr[0] = (v = parseInt(uuid.slice(0, 8), 16)) >>> 24;
-  arr[1] = v >>> 16 & 0xff;
-  arr[2] = v >>> 8 & 0xff;
-  arr[3] = v & 0xff; // Parse ........-####-....-....-............
-
-  arr[4] = (v = parseInt(uuid.slice(9, 13), 16)) >>> 8;
-  arr[5] = v & 0xff; // Parse ........-....-####-....-............
-
-  arr[6] = (v = parseInt(uuid.slice(14, 18), 16)) >>> 8;
-  arr[7] = v & 0xff; // Parse ........-....-....-####-............
-
-  arr[8] = (v = parseInt(uuid.slice(19, 23), 16)) >>> 8;
-  arr[9] = v & 0xff; // Parse ........-....-....-....-############
-  // (Use "/" to avoid 32-bit truncation when bit-shifting high-order bytes)
-
-  arr[10] = (v = parseInt(uuid.slice(24, 36), 16)) / 0x10000000000 & 0xff;
-  arr[11] = v / 0x100000000 & 0xff;
-  arr[12] = v >>> 24 & 0xff;
-  arr[13] = v >>> 16 & 0xff;
-  arr[14] = v >>> 8 & 0xff;
-  arr[15] = v & 0xff;
-  return arr;
-}
-
-var _default = parse;
-exports["default"] = _default;
-
-/***/ }),
-
-/***/ 7879:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = void 0;
-var _default = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
-exports["default"] = _default;
-
-/***/ }),
-
-/***/ 2973:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = rng;
-
-var _crypto = _interopRequireDefault(__nccwpck_require__(6982));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-const rnds8Pool = new Uint8Array(256); // # of random values to pre-allocate
-
-let poolPtr = rnds8Pool.length;
-
-function rng() {
-  if (poolPtr > rnds8Pool.length - 16) {
-    _crypto.default.randomFillSync(rnds8Pool);
-
-    poolPtr = 0;
-  }
-
-  return rnds8Pool.slice(poolPtr, poolPtr += 16);
-}
-
-/***/ }),
-
-/***/ 507:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = void 0;
-
-var _crypto = _interopRequireDefault(__nccwpck_require__(6982));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function sha1(bytes) {
-  if (Array.isArray(bytes)) {
-    bytes = Buffer.from(bytes);
-  } else if (typeof bytes === 'string') {
-    bytes = Buffer.from(bytes, 'utf8');
-  }
-
-  return _crypto.default.createHash('sha1').update(bytes).digest();
-}
-
-var _default = sha1;
-exports["default"] = _default;
-
-/***/ }),
-
-/***/ 7597:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = void 0;
-
-var _validate = _interopRequireDefault(__nccwpck_require__(6200));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-/**
- * Convert array of 16 byte values to UUID string format of the form:
- * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
- */
-const byteToHex = [];
-
-for (let i = 0; i < 256; ++i) {
-  byteToHex.push((i + 0x100).toString(16).substr(1));
-}
-
-function stringify(arr, offset = 0) {
-  // Note: Be careful editing this code!  It's been tuned for performance
-  // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
-  const uuid = (byteToHex[arr[offset + 0]] + byteToHex[arr[offset + 1]] + byteToHex[arr[offset + 2]] + byteToHex[arr[offset + 3]] + '-' + byteToHex[arr[offset + 4]] + byteToHex[arr[offset + 5]] + '-' + byteToHex[arr[offset + 6]] + byteToHex[arr[offset + 7]] + '-' + byteToHex[arr[offset + 8]] + byteToHex[arr[offset + 9]] + '-' + byteToHex[arr[offset + 10]] + byteToHex[arr[offset + 11]] + byteToHex[arr[offset + 12]] + byteToHex[arr[offset + 13]] + byteToHex[arr[offset + 14]] + byteToHex[arr[offset + 15]]).toLowerCase(); // Consistency check for valid UUID.  If this throws, it's likely due to one
-  // of the following:
-  // - One or more input array values don't map to a hex octet (leading to
-  // "undefined" in the uuid)
-  // - Invalid input values for the RFC `version` or `variant` fields
-
-  if (!(0, _validate.default)(uuid)) {
-    throw TypeError('Stringified UUID is invalid');
-  }
-
-  return uuid;
-}
-
-var _default = stringify;
-exports["default"] = _default;
-
-/***/ }),
-
-/***/ 6415:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = void 0;
-
-var _rng = _interopRequireDefault(__nccwpck_require__(2973));
-
-var _stringify = _interopRequireDefault(__nccwpck_require__(7597));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-// **`v1()` - Generate time-based UUID**
-//
-// Inspired by https://github.com/LiosK/UUID.js
-// and http://docs.python.org/library/uuid.html
-let _nodeId;
-
-let _clockseq; // Previous uuid creation time
-
-
-let _lastMSecs = 0;
-let _lastNSecs = 0; // See https://github.com/uuidjs/uuid for API details
-
-function v1(options, buf, offset) {
-  let i = buf && offset || 0;
-  const b = buf || new Array(16);
-  options = options || {};
-  let node = options.node || _nodeId;
-  let clockseq = options.clockseq !== undefined ? options.clockseq : _clockseq; // node and clockseq need to be initialized to random values if they're not
-  // specified.  We do this lazily to minimize issues related to insufficient
-  // system entropy.  See #189
-
-  if (node == null || clockseq == null) {
-    const seedBytes = options.random || (options.rng || _rng.default)();
-
-    if (node == null) {
-      // Per 4.5, create and 48-bit node id, (47 random bits + multicast bit = 1)
-      node = _nodeId = [seedBytes[0] | 0x01, seedBytes[1], seedBytes[2], seedBytes[3], seedBytes[4], seedBytes[5]];
-    }
-
-    if (clockseq == null) {
-      // Per 4.2.2, randomize (14 bit) clockseq
-      clockseq = _clockseq = (seedBytes[6] << 8 | seedBytes[7]) & 0x3fff;
-    }
-  } // UUID timestamps are 100 nano-second units since the Gregorian epoch,
-  // (1582-10-15 00:00).  JSNumbers aren't precise enough for this, so
-  // time is handled internally as 'msecs' (integer milliseconds) and 'nsecs'
-  // (100-nanoseconds offset from msecs) since unix epoch, 1970-01-01 00:00.
-
-
-  let msecs = options.msecs !== undefined ? options.msecs : Date.now(); // Per 4.2.1.2, use count of uuid's generated during the current clock
-  // cycle to simulate higher resolution clock
-
-  let nsecs = options.nsecs !== undefined ? options.nsecs : _lastNSecs + 1; // Time since last uuid creation (in msecs)
-
-  const dt = msecs - _lastMSecs + (nsecs - _lastNSecs) / 10000; // Per 4.2.1.2, Bump clockseq on clock regression
-
-  if (dt < 0 && options.clockseq === undefined) {
-    clockseq = clockseq + 1 & 0x3fff;
-  } // Reset nsecs if clock regresses (new clockseq) or we've moved onto a new
-  // time interval
-
-
-  if ((dt < 0 || msecs > _lastMSecs) && options.nsecs === undefined) {
-    nsecs = 0;
-  } // Per 4.2.1.2 Throw error if too many uuids are requested
-
-
-  if (nsecs >= 10000) {
-    throw new Error("uuid.v1(): Can't create more than 10M uuids/sec");
-  }
-
-  _lastMSecs = msecs;
-  _lastNSecs = nsecs;
-  _clockseq = clockseq; // Per 4.1.4 - Convert from unix epoch to Gregorian epoch
-
-  msecs += 12219292800000; // `time_low`
-
-  const tl = ((msecs & 0xfffffff) * 10000 + nsecs) % 0x100000000;
-  b[i++] = tl >>> 24 & 0xff;
-  b[i++] = tl >>> 16 & 0xff;
-  b[i++] = tl >>> 8 & 0xff;
-  b[i++] = tl & 0xff; // `time_mid`
-
-  const tmh = msecs / 0x100000000 * 10000 & 0xfffffff;
-  b[i++] = tmh >>> 8 & 0xff;
-  b[i++] = tmh & 0xff; // `time_high_and_version`
-
-  b[i++] = tmh >>> 24 & 0xf | 0x10; // include version
-
-  b[i++] = tmh >>> 16 & 0xff; // `clock_seq_hi_and_reserved` (Per 4.2.2 - include variant)
-
-  b[i++] = clockseq >>> 8 | 0x80; // `clock_seq_low`
-
-  b[i++] = clockseq & 0xff; // `node`
-
-  for (let n = 0; n < 6; ++n) {
-    b[i + n] = node[n];
-  }
-
-  return buf || (0, _stringify.default)(b);
-}
-
-var _default = v1;
-exports["default"] = _default;
-
-/***/ }),
-
-/***/ 1697:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = void 0;
-
-var _v = _interopRequireDefault(__nccwpck_require__(2930));
-
-var _md = _interopRequireDefault(__nccwpck_require__(216));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-const v3 = (0, _v.default)('v3', 0x30, _md.default);
-var _default = v3;
-exports["default"] = _default;
-
-/***/ }),
-
-/***/ 2930:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = _default;
-exports.URL = exports.DNS = void 0;
-
-var _stringify = _interopRequireDefault(__nccwpck_require__(7597));
-
-var _parse = _interopRequireDefault(__nccwpck_require__(7267));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function stringToBytes(str) {
-  str = unescape(encodeURIComponent(str)); // UTF8 escape
-
-  const bytes = [];
-
-  for (let i = 0; i < str.length; ++i) {
-    bytes.push(str.charCodeAt(i));
-  }
-
-  return bytes;
-}
-
-const DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
-exports.DNS = DNS;
-const URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
-exports.URL = URL;
-
-function _default(name, version, hashfunc) {
-  function generateUUID(value, namespace, buf, offset) {
-    if (typeof value === 'string') {
-      value = stringToBytes(value);
-    }
-
-    if (typeof namespace === 'string') {
-      namespace = (0, _parse.default)(namespace);
-    }
-
-    if (namespace.length !== 16) {
-      throw TypeError('Namespace must be array-like (16 iterable integer values, 0-255)');
-    } // Compute hash of namespace and value, Per 4.3
-    // Future: Use spread syntax when supported on all platforms, e.g. `bytes =
-    // hashfunc([...namespace, ... value])`
-
-
-    let bytes = new Uint8Array(16 + value.length);
-    bytes.set(namespace);
-    bytes.set(value, namespace.length);
-    bytes = hashfunc(bytes);
-    bytes[6] = bytes[6] & 0x0f | version;
-    bytes[8] = bytes[8] & 0x3f | 0x80;
-
-    if (buf) {
-      offset = offset || 0;
-
-      for (let i = 0; i < 16; ++i) {
-        buf[offset + i] = bytes[i];
-      }
-
-      return buf;
-    }
-
-    return (0, _stringify.default)(bytes);
-  } // Function#name is not settable on some platforms (#270)
-
-
-  try {
-    generateUUID.name = name; // eslint-disable-next-line no-empty
-  } catch (err) {} // For CommonJS default export support
-
-
-  generateUUID.DNS = DNS;
-  generateUUID.URL = URL;
-  return generateUUID;
-}
-
-/***/ }),
-
-/***/ 4676:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = void 0;
-
-var _rng = _interopRequireDefault(__nccwpck_require__(2973));
-
-var _stringify = _interopRequireDefault(__nccwpck_require__(7597));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function v4(options, buf, offset) {
-  options = options || {};
-
-  const rnds = options.random || (options.rng || _rng.default)(); // Per 4.4, set bits for version and `clock_seq_hi_and_reserved`
-
-
-  rnds[6] = rnds[6] & 0x0f | 0x40;
-  rnds[8] = rnds[8] & 0x3f | 0x80; // Copy bytes to buffer, if provided
-
-  if (buf) {
-    offset = offset || 0;
-
-    for (let i = 0; i < 16; ++i) {
-      buf[offset + i] = rnds[i];
-    }
-
-    return buf;
-  }
-
-  return (0, _stringify.default)(rnds);
-}
-
-var _default = v4;
-exports["default"] = _default;
-
-/***/ }),
-
-/***/ 9771:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = void 0;
-
-var _v = _interopRequireDefault(__nccwpck_require__(2930));
-
-var _sha = _interopRequireDefault(__nccwpck_require__(507));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-const v5 = (0, _v.default)('v5', 0x50, _sha.default);
-var _default = v5;
-exports["default"] = _default;
-
-/***/ }),
-
-/***/ 6200:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = void 0;
-
-var _regex = _interopRequireDefault(__nccwpck_require__(7879));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function validate(uuid) {
-  return typeof uuid === 'string' && _regex.default.test(uuid);
-}
-
-var _default = validate;
-exports["default"] = _default;
-
-/***/ }),
-
-/***/ 5868:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = void 0;
-
-var _validate = _interopRequireDefault(__nccwpck_require__(6200));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function version(uuid) {
-  if (!(0, _validate.default)(uuid)) {
-    throw TypeError('Invalid UUID');
-  }
-
-  return parseInt(uuid.substr(14, 1), 16);
-}
-
-var _default = version;
-exports["default"] = _default;
-
-/***/ }),
-
 /***/ 9962:
 /***/ ((module) => {
 
@@ -6053,9 +6759,7 @@ function loadConfigFromPath(configPath) {
 /***/ }),
 
 /***/ 8068:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-const core = __nccwpck_require__(7484)
+/***/ ((__unused_webpack_module, exports) => {
 
 const versionSeparator = '\n## '
 const semverLinkRegex =
@@ -6066,8 +6770,6 @@ const avoidNonVersionData = version =>
 
 exports.getEntries = rawData => {
   const content = String(rawData)
-
-  core.debug(`CHANGELOG content: ${content}`)
 
   return content.split(versionSeparator).filter(avoidNonVersionData)
 }
@@ -6090,9 +6792,7 @@ exports.getEntryByVersionID = (versions, id) => {
 /***/ }),
 
 /***/ 5045:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-const core = __nccwpck_require__(7484)
+/***/ ((__unused_webpack_module, exports) => {
 
 const linkRegex =
   /^\[.+\]:\s?(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/
@@ -6100,8 +6800,6 @@ const avoidNonVersionData = text => linkRegex.test(text)
 
 exports.getLinks = rawData => {
   const content = String(rawData)
-
-  core.debug(`CHANGELOG content: ${content}`)
 
   return content.trim().split('\n').filter(avoidNonVersionData)
 }
@@ -6462,6 +7160,14 @@ module.exports = require("assert");
 
 /***/ }),
 
+/***/ 5317:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("child_process");
+
+/***/ }),
+
 /***/ 6982:
 /***/ ((module) => {
 
@@ -6526,6 +7232,22 @@ module.exports = require("path");
 
 /***/ }),
 
+/***/ 3193:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("string_decoder");
+
+/***/ }),
+
+/***/ 3557:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("timers");
+
+/***/ }),
+
 /***/ 4756:
 /***/ ((module) => {
 
@@ -6542,15 +7264,15 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 5955:
+/***/ 3627:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var PlainValue = __nccwpck_require__(1346);
-var resolveSeq = __nccwpck_require__(1011);
-var Schema = __nccwpck_require__(3818);
+var PlainValue = __nccwpck_require__(9609);
+var resolveSeq = __nccwpck_require__(9091);
+var Schema = __nccwpck_require__(699);
 
 const defaultOptions = {
   anchorPrefix: 'a',
@@ -6571,43 +7293,33 @@ const scalarOptions = {
   get binary() {
     return resolveSeq.binaryOptions;
   },
-
   set binary(opt) {
     Object.assign(resolveSeq.binaryOptions, opt);
   },
-
   get bool() {
     return resolveSeq.boolOptions;
   },
-
   set bool(opt) {
     Object.assign(resolveSeq.boolOptions, opt);
   },
-
   get int() {
     return resolveSeq.intOptions;
   },
-
   set int(opt) {
     Object.assign(resolveSeq.intOptions, opt);
   },
-
   get null() {
     return resolveSeq.nullOptions;
   },
-
   set null(opt) {
     Object.assign(resolveSeq.nullOptions, opt);
   },
-
   get str() {
     return resolveSeq.strOptions;
   },
-
   set str(opt) {
     Object.assign(resolveSeq.strOptions, opt);
   }
-
 };
 const documentOptions = {
   '1.0': {
@@ -6652,14 +7364,11 @@ function stringifyTag(doc, tag) {
     const vocab = tag.match(/^tag:([a-zA-Z0-9-]+)\.yaml\.org,2002:(.*)/);
     return vocab ? `!${vocab[1]}/${vocab[2]}` : `!${tag.replace(/^tag:/, '')}`;
   }
-
   let p = doc.tagPrefixes.find(p => tag.indexOf(p.prefix) === 0);
-
   if (!p) {
     const dtp = doc.getDefaults().tagPrefixes;
     p = dtp && dtp.find(p => tag.indexOf(p.prefix) === 0);
   }
-
   if (!p) return tag[0] === '!' ? tag : `!<${tag}>`;
   const suffix = tag.substr(p.prefix.length).replace(/[!,[\]{}]/g, ch => ({
     '!': '%21',
@@ -6674,61 +7383,51 @@ function stringifyTag(doc, tag) {
 
 function getTagObject(tags, item) {
   if (item instanceof resolveSeq.Alias) return resolveSeq.Alias;
-
   if (item.tag) {
     const match = tags.filter(t => t.tag === item.tag);
     if (match.length > 0) return match.find(t => t.format === item.format) || match[0];
   }
-
   let tagObj, obj;
-
   if (item instanceof resolveSeq.Scalar) {
-    obj = item.value; // TODO: deprecate/remove class check
-
+    obj = item.value;
+    // TODO: deprecate/remove class check
     const match = tags.filter(t => t.identify && t.identify(obj) || t.class && obj instanceof t.class);
     tagObj = match.find(t => t.format === item.format) || match.find(t => !t.format);
   } else {
     obj = item;
     tagObj = tags.find(t => t.nodeClass && obj instanceof t.nodeClass);
   }
-
   if (!tagObj) {
     const name = obj && obj.constructor ? obj.constructor.name : typeof obj;
     throw new Error(`Tag not resolved for ${name} value`);
   }
-
   return tagObj;
-} // needs to be called before value stringifier to allow for circular anchor refs
+}
 
-
+// needs to be called before value stringifier to allow for circular anchor refs
 function stringifyProps(node, tagObj, {
   anchors,
   doc
 }) {
   const props = [];
   const anchor = doc.anchors.getName(node);
-
   if (anchor) {
     anchors[anchor] = node;
     props.push(`&${anchor}`);
   }
-
   if (node.tag) {
     props.push(stringifyTag(doc, node.tag));
   } else if (!tagObj.default) {
     props.push(stringifyTag(doc, tagObj.tag));
   }
-
   return props.join(' ');
 }
-
 function stringify(item, ctx, onComment, onChompKeep) {
   const {
     anchors,
     schema
   } = ctx.doc;
   let tagObj;
-
   if (!(item instanceof resolveSeq.Node)) {
     const createCtx = {
       aliasNodes: [],
@@ -6736,18 +7435,15 @@ function stringify(item, ctx, onComment, onChompKeep) {
       prevObjects: new Map()
     };
     item = schema.createNode(item, true, null, createCtx);
-
     for (const alias of createCtx.aliasNodes) {
       alias.source = alias.source.node;
       let name = anchors.getName(alias.source);
-
       if (!name) {
         name = anchors.newName();
         anchors.map[name] = alias.source;
       }
     }
   }
-
   if (item instanceof resolveSeq.Pair) return item.toString(ctx, onComment, onChompKeep);
   if (!tagObj) tagObj = getTagObject(schema.tags, item);
   const props = stringifyProps(item, tagObj, ctx);
@@ -6761,18 +7457,14 @@ class Anchors {
   static validAnchorNode(node) {
     return node instanceof resolveSeq.Scalar || node instanceof resolveSeq.YAMLSeq || node instanceof resolveSeq.YAMLMap;
   }
-
   constructor(prefix) {
     PlainValue._defineProperty(this, "map", Object.create(null));
-
     this.prefix = prefix;
   }
-
   createAlias(node, name) {
     this.setAnchor(node, name);
     return new resolveSeq.Alias(node);
   }
-
   createMergePair(...sources) {
     const merge = new resolveSeq.Merge();
     merge.value.items = sources.map(s => {
@@ -6781,38 +7473,32 @@ class Anchors {
       } else if (s instanceof resolveSeq.YAMLMap) {
         return this.createAlias(s);
       }
-
       throw new Error('Merge sources must be Map nodes or their Aliases');
     });
     return merge;
   }
-
   getName(node) {
     const {
       map
     } = this;
     return Object.keys(map).find(a => map[a] === node);
   }
-
   getNames() {
     return Object.keys(this.map);
   }
-
   getNode(name) {
     return this.map[name];
   }
-
   newName(prefix) {
     if (!prefix) prefix = this.prefix;
     const names = Object.keys(this.map);
-
     for (let i = 1; true; ++i) {
       const name = `${prefix}${i}`;
       if (!names.includes(name)) return name;
     }
-  } // During parsing, map & aliases contain CST nodes
+  }
 
-
+  // During parsing, map & aliases contain CST nodes
   resolveNodes() {
     const {
       map,
@@ -6821,28 +7507,22 @@ class Anchors {
     Object.keys(map).forEach(a => {
       map[a] = map[a].resolved;
     });
-
     _cstAliases.forEach(a => {
       a.source = a.source.resolved;
     });
-
     delete this._cstAliases;
   }
-
   setAnchor(node, name) {
     if (node != null && !Anchors.validAnchorNode(node)) {
       throw new Error('Anchors may only be set for Scalar, Seq and Map nodes');
     }
-
     if (name && /[\x00-\x19\s,[\]{}]/.test(name)) {
       throw new Error('Anchor names must not contain whitespace or control characters');
     }
-
     const {
       map
     } = this;
     const prev = node && Object.keys(map).find(a => map[a] === node);
-
     if (prev) {
       if (!name) {
         return prev;
@@ -6855,13 +7535,10 @@ class Anchors {
         if (!node) return null;
         name = this.newName();
       }
-
       map[name] = node;
     }
-
     return name;
   }
-
 }
 
 const visit = (node, tags) => {
@@ -6869,7 +7546,6 @@ const visit = (node, tags) => {
     const {
       tag
     } = node;
-
     if (node instanceof resolveSeq.Collection) {
       if (tag) tags[tag] = true;
       node.items.forEach(n => visit(n, tags));
@@ -6880,10 +7556,8 @@ const visit = (node, tags) => {
       if (tag) tags[tag] = true;
     }
   }
-
   return tags;
 };
-
 const listTagNames = node => Object.keys(visit(node, {}));
 
 function parseContents(doc, contents) {
@@ -6893,7 +7567,6 @@ function parseContents(doc, contents) {
   };
   let body = undefined;
   let spaceBefore = false;
-
   for (const node of contents) {
     if (node.valueRange) {
       if (body !== undefined) {
@@ -6901,21 +7574,17 @@ function parseContents(doc, contents) {
         doc.errors.push(new PlainValue.YAMLSyntaxError(node, msg));
         break;
       }
-
       const res = resolveSeq.resolveNode(doc, node);
-
       if (spaceBefore) {
         res.spaceBefore = true;
         spaceBefore = false;
       }
-
       body = res;
     } else if (node.comment !== null) {
       const cc = body === undefined ? comments.before : comments.after;
       cc.push(node.comment);
     } else if (node.type === PlainValue.Type.BLANK_LINE) {
       spaceBefore = true;
-
       if (body === undefined && comments.before.length > 0 && !doc.commentBefore) {
         // space-separated comments at start are parsed as document comments
         doc.commentBefore = comments.before.join('\n');
@@ -6923,19 +7592,15 @@ function parseContents(doc, contents) {
       }
     }
   }
-
   doc.contents = body || null;
-
   if (!body) {
     doc.comment = comments.before.concat(comments.after).join('\n') || null;
   } else {
     const cb = comments.before.join('\n');
-
     if (cb) {
       const cbNode = body instanceof resolveSeq.Collection && body.items[0] ? body.items[0] : body;
       cbNode.commentBefore = cbNode.commentBefore ? `${cb}\n${cbNode.commentBefore}` : cb;
     }
-
     doc.comment = comments.after.join('\n') || null;
   }
 }
@@ -6944,51 +7609,41 @@ function resolveTagDirective({
   tagPrefixes
 }, directive) {
   const [handle, prefix] = directive.parameters;
-
   if (!handle || !prefix) {
     const msg = 'Insufficient parameters given for %TAG directive';
     throw new PlainValue.YAMLSemanticError(directive, msg);
   }
-
   if (tagPrefixes.some(p => p.handle === handle)) {
     const msg = 'The %TAG directive must only be given at most once per handle in the same document.';
     throw new PlainValue.YAMLSemanticError(directive, msg);
   }
-
   return {
     handle,
     prefix
   };
 }
-
 function resolveYamlDirective(doc, directive) {
   let [version] = directive.parameters;
   if (directive.name === 'YAML:1.0') version = '1.0';
-
   if (!version) {
     const msg = 'Insufficient parameters given for %YAML directive';
     throw new PlainValue.YAMLSemanticError(directive, msg);
   }
-
   if (!documentOptions[version]) {
     const v0 = doc.version || doc.options.version;
     const msg = `Document will be parsed as YAML ${v0} rather than YAML ${version}`;
     doc.warnings.push(new PlainValue.YAMLWarning(directive, msg));
   }
-
   return version;
 }
-
 function parseDirectives(doc, directives, prevDoc) {
   const directiveComments = [];
   let hasDirectives = false;
-
   for (const directive of directives) {
     const {
       comment,
       name
     } = directive;
-
     switch (name) {
       case 'TAG':
         try {
@@ -6996,37 +7651,29 @@ function parseDirectives(doc, directives, prevDoc) {
         } catch (error) {
           doc.errors.push(error);
         }
-
         hasDirectives = true;
         break;
-
       case 'YAML':
       case 'YAML:1.0':
         if (doc.version) {
           const msg = 'The %YAML directive must only be given at most once per document.';
           doc.errors.push(new PlainValue.YAMLSemanticError(directive, msg));
         }
-
         try {
           doc.version = resolveYamlDirective(doc, directive);
         } catch (error) {
           doc.errors.push(error);
         }
-
         hasDirectives = true;
         break;
-
       default:
         if (name) {
           const msg = `YAML only supports %TAG and %YAML directives, and not %${name}`;
           doc.warnings.push(new PlainValue.YAMLWarning(directive, msg));
         }
-
     }
-
     if (comment) directiveComments.push(comment);
   }
-
   if (prevDoc && !hasDirectives && '1.1' === (doc.version || prevDoc.version || doc.options.version)) {
     const copyTagPrefix = ({
       handle,
@@ -7035,11 +7682,9 @@ function parseDirectives(doc, directives, prevDoc) {
       handle,
       prefix
     });
-
     doc.tagPrefixes = prevDoc.tagPrefixes.map(copyTagPrefix);
     doc.version = prevDoc.version;
   }
-
   doc.commentBefore = directiveComments.join('\n') || null;
 }
 
@@ -7047,7 +7692,6 @@ function assertCollection(contents) {
   if (contents instanceof resolveSeq.Collection) return true;
   throw new Error('Expected a YAML collection as document contents');
 }
-
 class Document {
   constructor(options) {
     this.anchors = new Anchors(options.anchorPrefix);
@@ -7062,83 +7706,67 @@ class Document {
     this.version = null;
     this.warnings = [];
   }
-
   add(value) {
     assertCollection(this.contents);
     return this.contents.add(value);
   }
-
   addIn(path, value) {
     assertCollection(this.contents);
     this.contents.addIn(path, value);
   }
-
   delete(key) {
     assertCollection(this.contents);
     return this.contents.delete(key);
   }
-
   deleteIn(path) {
     if (resolveSeq.isEmptyPath(path)) {
       if (this.contents == null) return false;
       this.contents = null;
       return true;
     }
-
     assertCollection(this.contents);
     return this.contents.deleteIn(path);
   }
-
   getDefaults() {
     return Document.defaults[this.version] || Document.defaults[this.options.version] || {};
   }
-
   get(key, keepScalar) {
     return this.contents instanceof resolveSeq.Collection ? this.contents.get(key, keepScalar) : undefined;
   }
-
   getIn(path, keepScalar) {
     if (resolveSeq.isEmptyPath(path)) return !keepScalar && this.contents instanceof resolveSeq.Scalar ? this.contents.value : this.contents;
     return this.contents instanceof resolveSeq.Collection ? this.contents.getIn(path, keepScalar) : undefined;
   }
-
   has(key) {
     return this.contents instanceof resolveSeq.Collection ? this.contents.has(key) : false;
   }
-
   hasIn(path) {
     if (resolveSeq.isEmptyPath(path)) return this.contents !== undefined;
     return this.contents instanceof resolveSeq.Collection ? this.contents.hasIn(path) : false;
   }
-
   set(key, value) {
     assertCollection(this.contents);
     this.contents.set(key, value);
   }
-
   setIn(path, value) {
     if (resolveSeq.isEmptyPath(path)) this.contents = value;else {
       assertCollection(this.contents);
       this.contents.setIn(path, value);
     }
   }
-
   setSchema(id, customTags) {
     if (!id && !customTags && this.schema) return;
     if (typeof id === 'number') id = id.toFixed(1);
-
     if (id === '1.0' || id === '1.1' || id === '1.2') {
       if (this.version) this.version = id;else this.options.version = id;
       delete this.options.schema;
     } else if (id && typeof id === 'string') {
       this.options.schema = id;
     }
-
     if (Array.isArray(customTags)) this.options.customTags = customTags;
     const opt = Object.assign({}, this.getDefaults(), this.options);
     this.schema = new Schema.Schema(opt);
   }
-
   parse(node, prevDoc) {
     if (this.options.keepCstNodes) this.cstNode = node;
     if (this.options.keepNodeTypes) this.type = 'DOCUMENT';
@@ -7149,12 +7777,10 @@ class Document {
       error,
       valueRange
     } = node;
-
     if (error) {
       if (!error.source) error.source = this;
       this.errors.push(error);
     }
-
     parseDirectives(this, directives, prevDoc);
     if (directivesEndMarker) this.directivesEndMarker = true;
     this.range = valueRange ? [valueRange.start, valueRange.end] : null;
@@ -7162,23 +7788,17 @@ class Document {
     this.anchors._cstAliases = [];
     parseContents(this, contents);
     this.anchors.resolveNodes();
-
     if (this.options.prettyErrors) {
       for (const error of this.errors) if (error instanceof PlainValue.YAMLError) error.makePretty();
-
       for (const warn of this.warnings) if (warn instanceof PlainValue.YAMLError) warn.makePretty();
     }
-
     return this;
   }
-
   listNonDefaultTags() {
     return listTagNames(this.contents).filter(t => t.indexOf(Schema.Schema.defaultPrefix) !== 0);
   }
-
   setTagPrefix(handle, prefix) {
     if (handle[0] !== '!' || handle[handle.length - 1] !== '!') throw new Error('Handle must start and end with !');
-
     if (prefix) {
       const prev = this.tagPrefixes.find(p => p.handle === handle);
       if (prev) prev.prefix = prefix;else this.tagPrefixes.push({
@@ -7189,7 +7809,6 @@ class Document {
       this.tagPrefixes = this.tagPrefixes.filter(p => p.handle !== handle);
     }
   }
-
   toJSON(arg, onAnchor) {
     const {
       keepBlobsInJSON,
@@ -7204,7 +7823,6 @@ class Document {
       mapAsMap: keep && !!mapAsMap,
       maxAliasCount,
       stringify // Requiring directly in Pair would create circular dependencies
-
     };
     const anchorNames = Object.keys(this.anchors.map);
     if (anchorNames.length > 0) ctx.anchors = new Map(anchorNames.map(name => [this.anchors.map[name], {
@@ -7219,31 +7837,24 @@ class Document {
     } of ctx.anchors.values()) onAnchor(res, count);
     return res;
   }
-
   toString() {
     if (this.errors.length > 0) throw new Error('Document with errors cannot be stringified');
     const indentSize = this.options.indent;
-
     if (!Number.isInteger(indentSize) || indentSize <= 0) {
       const s = JSON.stringify(indentSize);
       throw new Error(`"indent" option must be a positive integer, not ${s}`);
     }
-
     this.setSchema();
     const lines = [];
     let hasDirectives = false;
-
     if (this.version) {
       let vd = '%YAML 1.2';
-
       if (this.schema.name === 'yaml-1.1') {
         if (this.version === '1.0') vd = '%YAML:1.0';else if (this.version === '1.1') vd = '%YAML 1.1';
       }
-
       lines.push(vd);
       hasDirectives = true;
     }
-
     const tagNames = this.listNonDefaultTags();
     this.tagPrefixes.forEach(({
       handle,
@@ -7255,49 +7866,40 @@ class Document {
       }
     });
     if (hasDirectives || this.directivesEndMarker) lines.push('---');
-
     if (this.commentBefore) {
       if (hasDirectives || !this.directivesEndMarker) lines.unshift('');
       lines.unshift(this.commentBefore.replace(/^/gm, '#'));
     }
-
     const ctx = {
       anchors: Object.create(null),
       doc: this,
       indent: '',
       indentStep: ' '.repeat(indentSize),
       stringify // Requiring directly in nodes would create circular dependencies
-
     };
     let chompKeep = false;
     let contentComment = null;
-
     if (this.contents) {
       if (this.contents instanceof resolveSeq.Node) {
         if (this.contents.spaceBefore && (hasDirectives || this.directivesEndMarker)) lines.push('');
-        if (this.contents.commentBefore) lines.push(this.contents.commentBefore.replace(/^/gm, '#')); // top-level block scalars need to be indented if followed by a comment
-
+        if (this.contents.commentBefore) lines.push(this.contents.commentBefore.replace(/^/gm, '#'));
+        // top-level block scalars need to be indented if followed by a comment
         ctx.forceBlockIndent = !!this.comment;
         contentComment = this.contents.comment;
       }
-
       const onChompKeep = contentComment ? null : () => chompKeep = true;
       const body = stringify(this.contents, ctx, () => contentComment = null, onChompKeep);
       lines.push(resolveSeq.addComment(body, '', contentComment));
     } else if (this.contents !== undefined) {
       lines.push(stringify(this.contents, ctx));
     }
-
     if (this.comment) {
       if ((!chompKeep || contentComment) && lines[lines.length - 1] !== '') lines.push('');
       lines.push(this.comment.replace(/^/gm, '#'));
     }
-
     return lines.join('\n') + '\n';
   }
-
 }
-
 PlainValue._defineProperty(Document, "defaults", documentOptions);
 
 exports.Document = Document;
@@ -7307,7 +7909,7 @@ exports.scalarOptions = scalarOptions;
 
 /***/ }),
 
-/***/ 1346:
+/***/ 9609:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -7349,37 +7951,32 @@ const defaultTags = {
 function findLineStarts(src) {
   const ls = [0];
   let offset = src.indexOf('\n');
-
   while (offset !== -1) {
     offset += 1;
     ls.push(offset);
     offset = src.indexOf('\n', offset);
   }
-
   return ls;
 }
-
 function getSrcInfo(cst) {
   let lineStarts, src;
-
   if (typeof cst === 'string') {
     lineStarts = findLineStarts(cst);
     src = cst;
   } else {
     if (Array.isArray(cst)) cst = cst[0];
-
     if (cst && cst.context) {
       if (!cst.lineStarts) cst.lineStarts = findLineStarts(cst.context.src);
       lineStarts = cst.lineStarts;
       src = cst.context.src;
     }
   }
-
   return {
     lineStarts,
     src
   };
 }
+
 /**
  * @typedef {Object} LinePos - One-indexed position in the source
  * @property {number} line
@@ -7400,8 +7997,6 @@ function getSrcInfo(cst) {
  * @param {string|Document|Document[]} cst
  * @returns {?LinePos}
  */
-
-
 function getLinePos(offset, cst) {
   if (typeof offset !== 'number' || offset < 0) return null;
   const {
@@ -7409,29 +8004,26 @@ function getLinePos(offset, cst) {
     src
   } = getSrcInfo(cst);
   if (!lineStarts || !src || offset > src.length) return null;
-
   for (let i = 0; i < lineStarts.length; ++i) {
     const start = lineStarts[i];
-
     if (offset < start) {
       return {
         line: i,
         col: offset - lineStarts[i - 1] + 1
       };
     }
-
     if (offset === start) return {
       line: i + 1,
       col: 1
     };
   }
-
   const line = lineStarts.length;
   return {
     line,
     col: offset - lineStarts[line - 1] + 1
   };
 }
+
 /**
  * Get a specified line from the source.
  *
@@ -7445,7 +8037,6 @@ function getLinePos(offset, cst) {
  * @param {string|Document|Document[]} cst
  * @returns {?string}
  */
-
 function getLine(line, cst) {
   const {
     lineStarts,
@@ -7454,11 +8045,10 @@ function getLine(line, cst) {
   if (!lineStarts || !(line >= 1) || line > lineStarts.length) return null;
   const start = lineStarts[line - 1];
   let end = lineStarts[line]; // undefined for last line; that's ok for slice()
-
   while (end && end > start && src[end - 1] === '\n') --end;
-
   return src.slice(start, end);
 }
+
 /**
  * Pretty-print the starting line from the source indicated by the range `pos`
  *
@@ -7475,7 +8065,6 @@ function getLine(line, cst) {
  * @param {number} [maxWidth=80]
  * @returns {?string}
  */
-
 function getPrettyContext({
   start,
   end
@@ -7485,7 +8074,6 @@ function getPrettyContext({
   let {
     col
   } = start;
-
   if (src.length > maxWidth) {
     if (col <= maxWidth - 10) {
       src = src.substr(0, maxWidth - 1) + '…';
@@ -7496,10 +8084,8 @@ function getPrettyContext({
       src = '…' + src.substr(1 - maxWidth);
     }
   }
-
   let errLen = 1;
   let errEnd = '';
-
   if (end) {
     if (end.line === start.line && col + (end.col - start.col) <= maxWidth + 1) {
       errLen = end.col - start.col;
@@ -7508,7 +8094,6 @@ function getPrettyContext({
       errEnd = '…';
     }
   }
-
   const offset = col > 1 ? ' '.repeat(col - 1) : '';
   const err = '^'.repeat(errLen);
   return `${src}\n${offset}${err}${errEnd}`;
@@ -7518,15 +8103,14 @@ class Range {
   static copy(orig) {
     return new Range(orig.start, orig.end);
   }
-
   constructor(start, end) {
     this.start = start;
     this.end = end || start;
   }
-
   isEmpty() {
     return typeof this.start !== 'number' || !this.end || this.end <= this.start;
   }
+
   /**
    * Set `origStart` and `origEnd` to point to the original source range for
    * this node, which may differ due to dropped CR characters.
@@ -7535,112 +8119,86 @@ class Range {
    * @param {number} offset - Starting index of `cr` from the last call
    * @returns {number} - The next offset, matching the one found for `origStart`
    */
-
-
   setOrigRange(cr, offset) {
     const {
       start,
       end
     } = this;
-
     if (cr.length === 0 || end <= cr[0]) {
       this.origStart = start;
       this.origEnd = end;
       return offset;
     }
-
     let i = offset;
-
     while (i < cr.length) {
       if (cr[i] > start) break;else ++i;
     }
-
     this.origStart = start + i;
     const nextOffset = i;
-
     while (i < cr.length) {
       // if end was at \n, it should now be at \r
       if (cr[i] >= end) break;else ++i;
     }
-
     this.origEnd = end + i;
     return nextOffset;
   }
-
 }
 
 /** Root class of all nodes */
-
 class Node {
   static addStringTerminator(src, offset, str) {
     if (str[str.length - 1] === '\n') return str;
     const next = Node.endOfWhiteSpace(src, offset);
     return next >= src.length || src[next] === '\n' ? str + '\n' : str;
-  } // ^(---|...)
+  }
 
-
+  // ^(---|...)
   static atDocumentBoundary(src, offset, sep) {
     const ch0 = src[offset];
     if (!ch0) return true;
     const prev = src[offset - 1];
     if (prev && prev !== '\n') return false;
-
     if (sep) {
       if (ch0 !== sep) return false;
     } else {
       if (ch0 !== Char.DIRECTIVES_END && ch0 !== Char.DOCUMENT_END) return false;
     }
-
     const ch1 = src[offset + 1];
     const ch2 = src[offset + 2];
     if (ch1 !== ch0 || ch2 !== ch0) return false;
     const ch3 = src[offset + 3];
     return !ch3 || ch3 === '\n' || ch3 === '\t' || ch3 === ' ';
   }
-
   static endOfIdentifier(src, offset) {
     let ch = src[offset];
     const isVerbatim = ch === '<';
     const notOk = isVerbatim ? ['\n', '\t', ' ', '>'] : ['\n', '\t', ' ', '[', ']', '{', '}', ','];
-
     while (ch && notOk.indexOf(ch) === -1) ch = src[offset += 1];
-
     if (isVerbatim && ch === '>') offset += 1;
     return offset;
   }
-
   static endOfIndent(src, offset) {
     let ch = src[offset];
-
     while (ch === ' ') ch = src[offset += 1];
-
     return offset;
   }
-
   static endOfLine(src, offset) {
     let ch = src[offset];
-
     while (ch && ch !== '\n') ch = src[offset += 1];
-
     return offset;
   }
-
   static endOfWhiteSpace(src, offset) {
     let ch = src[offset];
-
     while (ch === '\t' || ch === ' ') ch = src[offset += 1];
-
     return offset;
   }
-
   static startOfLine(src, offset) {
     let ch = src[offset - 1];
     if (ch === '\n') return offset;
-
     while (ch && ch !== '\n') ch = src[offset -= 1];
-
     return offset + 1;
   }
+
   /**
    * End of indentation, or null if the line's indent level is not more
    * than `indent`
@@ -7650,11 +8208,8 @@ class Node {
    * @param {number} lineStart
    * @returns {?number}
    */
-
-
   static endOfBlockIndent(src, indent, lineStart) {
     const inEnd = Node.endOfIndent(src, lineStart);
-
     if (inEnd > lineStart + indent) {
       return inEnd;
     } else {
@@ -7662,35 +8217,31 @@ class Node {
       const ch = src[wsEnd];
       if (!ch || ch === '\n') return wsEnd;
     }
-
     return null;
   }
-
   static atBlank(src, offset, endAsBlank) {
     const ch = src[offset];
     return ch === '\n' || ch === '\t' || ch === ' ' || endAsBlank && !ch;
   }
-
   static nextNodeIsIndented(ch, indentDiff, indicatorAsIndent) {
     if (!ch || indentDiff < 0) return false;
     if (indentDiff > 0) return true;
     return indicatorAsIndent && ch === '-';
-  } // should be at line or string end, or at next non-whitespace char
+  }
 
-
+  // should be at line or string end, or at next non-whitespace char
   static normalizeOffset(src, offset) {
     const ch = src[offset];
     return !ch ? offset : ch !== '\n' && src[offset - 1] === '\n' ? offset - 1 : Node.endOfWhiteSpace(src, offset);
-  } // fold single newline into space, multiple newlines to N - 1 newlines
+  }
+
+  // fold single newline into space, multiple newlines to N - 1 newlines
   // presumes src[offset] === '\n'
-
-
   static foldNewline(src, offset, indent) {
     let inCount = 0;
     let error = false;
     let fold = '';
     let ch = src[offset + 1];
-
     while (ch === ' ' || ch === '\t' || ch === '\n') {
       switch (ch) {
         case '\n':
@@ -7698,21 +8249,17 @@ class Node {
           offset += 1;
           fold += '\n';
           break;
-
         case '\t':
           if (inCount <= indent) error = true;
           offset = Node.endOfWhiteSpace(src, offset + 2) - 1;
           break;
-
         case ' ':
           inCount += 1;
           offset += 1;
           break;
       }
-
       ch = src[offset + 1];
     }
-
     if (!fold) fold = ' ';
     if (ch && inCount <= indent) error = true;
     return {
@@ -7721,7 +8268,6 @@ class Node {
       error
     };
   }
-
   constructor(type, props, context) {
     Object.defineProperty(this, 'context', {
       value: context || null,
@@ -7734,7 +8280,6 @@ class Node {
     this.type = type;
     this.value = null;
   }
-
   getPropValue(idx, key, skipKey) {
     if (!this.context) return null;
     const {
@@ -7743,27 +8288,21 @@ class Node {
     const prop = this.props[idx];
     return prop && src[prop.start] === key ? src.slice(prop.start + (skipKey ? 1 : 0), prop.end) : null;
   }
-
   get anchor() {
     for (let i = 0; i < this.props.length; ++i) {
       const anchor = this.getPropValue(i, Char.ANCHOR, true);
       if (anchor != null) return anchor;
     }
-
     return null;
   }
-
   get comment() {
     const comments = [];
-
     for (let i = 0; i < this.props.length; ++i) {
       const comment = this.getPropValue(i, Char.COMMENT, true);
       if (comment != null) comments.push(comment);
     }
-
     return comments.length > 0 ? comments.join('\n') : null;
   }
-
   commentHasRequiredWhitespace(start) {
     const {
       src
@@ -7775,44 +8314,35 @@ class Node {
     } = this.valueRange;
     return start !== end || Node.atBlank(src, end - 1);
   }
-
   get hasComment() {
     if (this.context) {
       const {
         src
       } = this.context;
-
       for (let i = 0; i < this.props.length; ++i) {
         if (src[this.props[i].start] === Char.COMMENT) return true;
       }
     }
-
     return false;
   }
-
   get hasProps() {
     if (this.context) {
       const {
         src
       } = this.context;
-
       for (let i = 0; i < this.props.length; ++i) {
         if (src[this.props[i].start] !== Char.COMMENT) return true;
       }
     }
-
     return false;
   }
-
   get includesTrailingLines() {
     return false;
   }
-
   get jsonLike() {
     const jsonLikeTypes = [Type.FLOW_MAP, Type.FLOW_SEQ, Type.QUOTE_DOUBLE, Type.QUOTE_SINGLE];
     return jsonLikeTypes.indexOf(this.type) !== -1;
   }
-
   get rangeAsLinePos() {
     if (!this.range || !this.context) return undefined;
     const start = getLinePos(this.range.start, this.context.root);
@@ -7823,7 +8353,6 @@ class Node {
       end
     };
   }
-
   get rawValue() {
     if (!this.valueRange || !this.context) return null;
     const {
@@ -7832,11 +8361,9 @@ class Node {
     } = this.valueRange;
     return this.context.src.slice(start, end);
   }
-
   get tag() {
     for (let i = 0; i < this.props.length; ++i) {
       const tag = this.getPropValue(i, Char.TAG, false);
-
       if (tag != null) {
         if (tag[1] === '<') {
           return {
@@ -7852,10 +8379,8 @@ class Node {
         }
       }
     }
-
     return null;
   }
-
   get valueRangeContainsNewline() {
     if (!this.valueRange || !this.context) return false;
     const {
@@ -7865,28 +8390,24 @@ class Node {
     const {
       src
     } = this.context;
-
     for (let i = start; i < end; ++i) {
       if (src[i] === '\n') return true;
     }
-
     return false;
   }
-
   parseComment(start) {
     const {
       src
     } = this.context;
-
     if (src[start] === Char.COMMENT) {
       const end = Node.endOfLine(src, start + 1);
       const commentRange = new Range(start, end);
       this.props.push(commentRange);
       return end;
     }
-
     return start;
   }
+
   /**
    * Populates the `origStart` and `origEnd` values of all ranges for this
    * node. Extended by child classes to handle descendant nodes.
@@ -7895,15 +8416,12 @@ class Node {
    * @param {number} offset - Starting index of `cr` from the last call
    * @returns {number} - The next offset, matching the one found for `origStart`
    */
-
-
   setOrigRanges(cr, offset) {
     if (this.range) offset = this.range.setOrigRange(cr, offset);
     if (this.valueRange) this.valueRange.setOrigRange(cr, offset);
     this.props.forEach(prop => prop.setOrigRange(cr, offset));
     return offset;
   }
-
   toString() {
     const {
       context: {
@@ -7916,7 +8434,6 @@ class Node {
     const str = src.slice(range.start, range.end);
     return Node.addStringTerminator(src, range.end, str);
   }
-
 }
 
 class YAMLError extends Error {
@@ -7927,16 +8444,13 @@ class YAMLError extends Error {
     this.message = message;
     this.source = source;
   }
-
   makePretty() {
     if (!this.source) return;
     this.nodeType = this.source.type;
     const cst = this.source.context && this.source.context.root;
-
     if (typeof this.offset === 'number') {
       this.range = new Range(this.offset, this.offset + 1);
       const start = cst && getLinePos(this.offset, cst);
-
       if (start) {
         const end = {
           line: start.line,
@@ -7947,13 +8461,11 @@ class YAMLError extends Error {
           end
         };
       }
-
       delete this.offset;
     } else {
       this.range = this.source.range;
       this.linePos = this.source.rangeAsLinePos;
     }
-
     if (this.linePos) {
       const {
         line,
@@ -7963,56 +8475,57 @@ class YAMLError extends Error {
       const ctx = cst && getPrettyContext(this.linePos, cst);
       if (ctx) this.message += `:\n\n${ctx}\n`;
     }
-
     delete this.source;
   }
-
 }
 class YAMLReferenceError extends YAMLError {
   constructor(source, message) {
     super('YAMLReferenceError', source, message);
   }
-
 }
 class YAMLSemanticError extends YAMLError {
   constructor(source, message) {
     super('YAMLSemanticError', source, message);
   }
-
 }
 class YAMLSyntaxError extends YAMLError {
   constructor(source, message) {
     super('YAMLSyntaxError', source, message);
   }
-
 }
 class YAMLWarning extends YAMLError {
   constructor(source, message) {
     super('YAMLWarning', source, message);
   }
-
 }
 
-function _defineProperty(obj, key, value) {
-  if (key in obj) {
-    Object.defineProperty(obj, key, {
-      value: value,
-      enumerable: true,
-      configurable: true,
-      writable: true
-    });
-  } else {
-    obj[key] = value;
+function _defineProperty(e, r, t) {
+  return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
+    value: t,
+    enumerable: !0,
+    configurable: !0,
+    writable: !0
+  }) : e[r] = t, e;
+}
+function _toPrimitive(t, r) {
+  if ("object" != typeof t || !t) return t;
+  var e = t[Symbol.toPrimitive];
+  if (void 0 !== e) {
+    var i = e.call(t, r || "default");
+    if ("object" != typeof i) return i;
+    throw new TypeError("@@toPrimitive must return a primitive value.");
   }
-
-  return obj;
+  return ("string" === r ? String : Number)(t);
+}
+function _toPropertyKey(t) {
+  var i = _toPrimitive(t, "string");
+  return "symbol" == typeof i ? i : i + "";
 }
 
 class PlainValue extends Node {
   static endOfLine(src, start, inFlow) {
     let ch = src[start];
     let offset = start;
-
     while (ch && ch !== '\n') {
       if (inFlow && (ch === '[' || ch === ']' || ch === '{' || ch === '}' || ch === ',')) break;
       const next = src[offset + 1];
@@ -8021,10 +8534,8 @@ class PlainValue extends Node {
       offset += 1;
       ch = next;
     }
-
     return offset;
   }
-
   get strValue() {
     if (!this.valueRange || !this.context) return null;
     let {
@@ -8035,14 +8546,10 @@ class PlainValue extends Node {
       src
     } = this.context;
     let ch = src[end - 1];
-
     while (start < end && (ch === '\n' || ch === '\t' || ch === ' ')) ch = src[--end - 1];
-
     let str = '';
-
     for (let i = start; i < end; ++i) {
       const ch = src[i];
-
       if (ch === '\n') {
         const {
           fold,
@@ -8054,20 +8561,16 @@ class PlainValue extends Node {
         // trim trailing whitespace
         const wsStart = i;
         let next = src[i + 1];
-
         while (i < end && (next === ' ' || next === '\t')) {
           i += 1;
           next = src[i + 1];
         }
-
         if (next !== '\n') str += i > wsStart ? src.slice(wsStart, i + 1) : ch;
       } else {
         str += ch;
       }
     }
-
     const ch0 = src[start];
-
     switch (ch0) {
       case '\t':
         {
@@ -8078,7 +8581,6 @@ class PlainValue extends Node {
             str
           };
         }
-
       case '@':
       case '`':
         {
@@ -8089,12 +8591,10 @@ class PlainValue extends Node {
             str
           };
         }
-
       default:
         return str;
     }
   }
-
   parseBlockValue(start) {
     const {
       indent,
@@ -8103,12 +8603,10 @@ class PlainValue extends Node {
     } = this.context;
     let offset = start;
     let valueEnd = start;
-
     for (let ch = src[offset]; ch === '\n'; ch = src[offset]) {
       if (Node.atDocumentBoundary(src, offset + 1)) break;
       const end = Node.endOfBlockIndent(src, indent, offset + 1);
       if (end === null || src[end] === '#') break;
-
       if (src[end] === '\n') {
         offset = end;
       } else {
@@ -8116,11 +8614,11 @@ class PlainValue extends Node {
         offset = valueEnd;
       }
     }
-
     if (this.valueRange.isEmpty()) this.valueRange.start = start;
     this.valueRange.end = valueEnd;
     return valueEnd;
   }
+
   /**
    * Parses a plain value from the source
    *
@@ -8146,8 +8644,6 @@ class PlainValue extends Node {
    * @param {number} start - Index of first character
    * @returns {number} - Index of the character after this scalar, may be `\n`
    */
-
-
   parse(context, start) {
     this.context = context;
     const {
@@ -8156,22 +8652,17 @@ class PlainValue extends Node {
     } = context;
     let offset = start;
     const ch = src[offset];
-
     if (ch && ch !== '#' && ch !== '\n') {
       offset = PlainValue.endOfLine(src, start, inFlow);
     }
-
     this.valueRange = new Range(start, offset);
     offset = Node.endOfWhiteSpace(src, offset);
     offset = this.parseComment(offset);
-
     if (!this.hasComment || this.valueRange.isEmpty()) {
       offset = this.parseBlockValue(offset);
     }
-
     return offset;
   }
-
 }
 
 exports.Char = Char;
@@ -8191,32 +8682,28 @@ exports.defaultTags = defaultTags;
 
 /***/ }),
 
-/***/ 3818:
+/***/ 699:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var PlainValue = __nccwpck_require__(1346);
-var resolveSeq = __nccwpck_require__(1011);
-var warnings = __nccwpck_require__(1747);
+var PlainValue = __nccwpck_require__(9609);
+var resolveSeq = __nccwpck_require__(9091);
+var warnings = __nccwpck_require__(5058);
 
 function createMap(schema, obj, ctx) {
   const map = new resolveSeq.YAMLMap(schema);
-
   if (obj instanceof Map) {
     for (const [key, value] of obj) map.items.push(schema.createPair(key, value, ctx));
   } else if (obj && typeof obj === 'object') {
     for (const key of Object.keys(obj)) map.items.push(schema.createPair(key, obj[key], ctx));
   }
-
   if (typeof schema.sortMapEntries === 'function') {
     map.items.sort(schema.sortMapEntries);
   }
-
   return map;
 }
-
 const map = {
   createNode: createMap,
   default: true,
@@ -8227,17 +8714,14 @@ const map = {
 
 function createSeq(schema, obj, ctx) {
   const seq = new resolveSeq.YAMLSeq(schema);
-
   if (obj && obj[Symbol.iterator]) {
     for (const it of obj) {
       const v = schema.createNode(it, ctx.wrapScalars, null, ctx);
       seq.items.push(v);
     }
   }
-
   return seq;
 }
-
 const seq = {
   createNode: createSeq,
   default: true,
@@ -8251,25 +8735,20 @@ const string = {
   default: true,
   tag: 'tag:yaml.org,2002:str',
   resolve: resolveSeq.resolveString,
-
   stringify(item, ctx, onComment, onChompKeep) {
     ctx = Object.assign({
       actualString: true
     }, ctx);
     return resolveSeq.stringifyString(item, ctx, onComment, onChompKeep);
   },
-
   options: resolveSeq.strOptions
 };
 
 const failsafe = [map, seq, string];
 
 /* global BigInt */
-
 const intIdentify$2 = value => typeof value === 'bigint' || Number.isInteger(value);
-
 const intResolve$1 = (src, part, radix) => resolveSeq.intOptions.asBigInt ? BigInt(src) : parseInt(part, radix);
-
 function intStringify$1(node, radix, prefix) {
   const {
     value
@@ -8277,7 +8756,6 @@ function intStringify$1(node, radix, prefix) {
   if (intIdentify$2(value) && value >= 0) return prefix + value.toString(radix);
   return resolveSeq.stringifyNumber(node);
 }
-
 const nullObj = {
   identify: value => value == null,
   createNode: (schema, value, ctx) => ctx.wrapScalars ? new resolveSeq.Scalar(null) : null,
@@ -8352,26 +8830,21 @@ const floatObj = {
   default: true,
   tag: 'tag:yaml.org,2002:float',
   test: /^[-+]?(?:\.([0-9]+)|[0-9]+\.([0-9]*))$/,
-
   resolve(str, frac1, frac2) {
     const frac = frac1 || frac2;
     const node = new resolveSeq.Scalar(parseFloat(str));
     if (frac && frac[frac.length - 1] === '0') node.minFractionDigits = frac.length;
     return node;
   },
-
   stringify: resolveSeq.stringifyNumber
 };
 const core = failsafe.concat([nullObj, boolObj, octObj, intObj, hexObj, nanObj, expObj, floatObj]);
 
 /* global BigInt */
-
 const intIdentify$1 = value => typeof value === 'bigint' || Number.isInteger(value);
-
 const stringifyJSON = ({
   value
 }) => JSON.stringify(value);
-
 const json = [map, seq, {
   identify: value => typeof value === 'string',
   default: true,
@@ -8410,58 +8883,45 @@ const json = [map, seq, {
   resolve: str => parseFloat(str),
   stringify: stringifyJSON
 }];
-
 json.scalarFallback = str => {
   throw new SyntaxError(`Unresolved plain scalar ${JSON.stringify(str)}`);
 };
 
 /* global BigInt */
-
 const boolStringify = ({
   value
 }) => value ? resolveSeq.boolOptions.trueStr : resolveSeq.boolOptions.falseStr;
-
 const intIdentify = value => typeof value === 'bigint' || Number.isInteger(value);
-
 function intResolve(sign, src, radix) {
   let str = src.replace(/_/g, '');
-
   if (resolveSeq.intOptions.asBigInt) {
     switch (radix) {
       case 2:
         str = `0b${str}`;
         break;
-
       case 8:
         str = `0o${str}`;
         break;
-
       case 16:
         str = `0x${str}`;
         break;
     }
-
     const n = BigInt(str);
     return sign === '-' ? BigInt(-1) * n : n;
   }
-
   const n = parseInt(str, radix);
   return sign === '-' ? -1 * n : n;
 }
-
 function intStringify(node, radix, prefix) {
   const {
     value
   } = node;
-
   if (intIdentify(value)) {
     const str = value.toString(radix);
     return value < 0 ? '-' + prefix + str.substr(1) : prefix + str;
   }
-
   return resolveSeq.stringifyNumber(node);
 }
-
 const yaml11 = failsafe.concat([{
   identify: value => value == null,
   createNode: (schema, value, ctx) => ctx.wrapScalars ? new resolveSeq.Scalar(null) : null,
@@ -8540,18 +9000,14 @@ const yaml11 = failsafe.concat([{
   default: true,
   tag: 'tag:yaml.org,2002:float',
   test: /^[-+]?(?:[0-9][0-9_]*)?\.([0-9_]*)$/,
-
   resolve(str, frac) {
     const node = new resolveSeq.Scalar(parseFloat(str.replace(/_/g, '')));
-
     if (frac) {
       const f = frac.replace(/_/g, '');
       if (f[f.length - 1] === '0') node.minFractionDigits = f.length;
     }
-
     return node;
   },
-
   stringify: resolveSeq.stringifyNumber
 }], warnings.binary, warnings.omap, warnings.pairs, warnings.set, warnings.intTime, warnings.floatTime, warnings.timestamp);
 
@@ -8587,12 +9043,11 @@ function findTagObject(value, tagName, tags) {
     const tagObj = match.find(t => !t.format) || match[0];
     if (!tagObj) throw new Error(`Tag ${tagName} not found`);
     return tagObj;
-  } // TODO: deprecate/remove class check
+  }
 
-
+  // TODO: deprecate/remove class check
   return tags.find(t => (t.identify && t.identify(value) || t.class && value instanceof t.class) && !t.format);
 }
-
 function createNode(value, tagName, ctx) {
   if (value instanceof resolveSeq.Node) return value;
   const {
@@ -8604,40 +9059,32 @@ function createNode(value, tagName, ctx) {
   } = ctx;
   if (tagName && tagName.startsWith('!!')) tagName = defaultPrefix + tagName.slice(2);
   let tagObj = findTagObject(value, tagName, schema.tags);
-
   if (!tagObj) {
     if (typeof value.toJSON === 'function') value = value.toJSON();
     if (!value || typeof value !== 'object') return wrapScalars ? new resolveSeq.Scalar(value) : value;
     tagObj = value instanceof Map ? map : value[Symbol.iterator] ? seq : map;
   }
-
   if (onTagObj) {
     onTagObj(tagObj);
     delete ctx.onTagObj;
-  } // Detect duplicate references to the same object & use Alias nodes for all
+  }
+
+  // Detect duplicate references to the same object & use Alias nodes for all
   // after first. The `obj` wrapper allows for circular references to resolve.
-
-
   const obj = {
     value: undefined,
     node: undefined
   };
-
   if (value && typeof value === 'object' && prevObjects) {
     const prev = prevObjects.get(value);
-
     if (prev) {
       const alias = new resolveSeq.Alias(prev); // leaves source dirty; must be cleaned by caller
-
       ctx.aliasNodes.push(alias); // defined along with prevObjects
-
       return alias;
     }
-
     obj.value = value;
     prevObjects.set(value, obj);
   }
-
   obj.node = tagObj.createNode ? tagObj.createNode(ctx.schema, value, ctx) : wrapScalars ? new resolveSeq.Scalar(value) : value;
   if (tagName && obj.node instanceof resolveSeq.Node) obj.node.tag = tagName;
   return obj.node;
@@ -8645,41 +9092,33 @@ function createNode(value, tagName, ctx) {
 
 function getSchemaTags(schemas, knownTags, customTags, schemaId) {
   let tags = schemas[schemaId.replace(/\W/g, '')]; // 'yaml-1.1' -> 'yaml11'
-
   if (!tags) {
     const keys = Object.keys(schemas).map(key => JSON.stringify(key)).join(', ');
     throw new Error(`Unknown schema "${schemaId}"; use one of ${keys}`);
   }
-
   if (Array.isArray(customTags)) {
     for (const tag of customTags) tags = tags.concat(tag);
   } else if (typeof customTags === 'function') {
     tags = customTags(tags.slice());
   }
-
   for (let i = 0; i < tags.length; ++i) {
     const tag = tags[i];
-
     if (typeof tag === 'string') {
       const tagObj = knownTags[tag];
-
       if (!tagObj) {
         const keys = Object.keys(knownTags).map(key => JSON.stringify(key)).join(', ');
         throw new Error(`Unknown custom tag "${tag}"; use one of ${keys}`);
       }
-
       tags[i] = tagObj;
     }
   }
-
   return tags;
 }
 
 const sortMapEntriesByKey = (a, b) => a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
-
 class Schema {
   // TODO: remove in v2
-  // TODO: remove in v2
+
   constructor({
     customTags,
     merge,
@@ -8693,7 +9132,6 @@ class Schema {
     if (!customTags && deprecatedCustomTags) warnings.warnOptionDeprecation('tags', 'customTags');
     this.tags = getSchemaTags(schemas, tags, customTags || deprecatedCustomTags, schema);
   }
-
   createNode(value, wrapScalars, tagName, ctx) {
     const baseCtx = {
       defaultPrefix: Schema.defaultPrefix,
@@ -8703,7 +9141,6 @@ class Schema {
     const createCtx = ctx ? Object.assign(ctx, baseCtx) : baseCtx;
     return createNode(value, tagName, createCtx);
   }
-
   createPair(key, value, ctx) {
     if (!ctx) ctx = {
       wrapScalars: true
@@ -8712,11 +9149,9 @@ class Schema {
     const v = this.createNode(value, ctx.wrapScalars, null, ctx);
     return new resolveSeq.Pair(k, v);
   }
-
 }
-
 PlainValue._defineProperty(Schema, "defaultPrefix", PlainValue.defaultTagPrefix);
-
+// TODO: remove in v2
 PlainValue._defineProperty(Schema, "defaultTags", PlainValue.defaultTags);
 
 exports.Schema = Schema;
@@ -8731,69 +9166,57 @@ exports.Schema = Schema;
 
 
 var parseCst = __nccwpck_require__(4587);
-var Document$1 = __nccwpck_require__(5955);
-var Schema = __nccwpck_require__(3818);
-var PlainValue = __nccwpck_require__(1346);
-var warnings = __nccwpck_require__(1747);
-__nccwpck_require__(1011);
+var Document$1 = __nccwpck_require__(3627);
+var Schema = __nccwpck_require__(699);
+var PlainValue = __nccwpck_require__(9609);
+var warnings = __nccwpck_require__(5058);
+__nccwpck_require__(9091);
 
 function createNode(value, wrapScalars = true, tag) {
   if (tag === undefined && typeof wrapScalars === 'string') {
     tag = wrapScalars;
     wrapScalars = true;
   }
-
   const options = Object.assign({}, Document$1.Document.defaults[Document$1.defaultOptions.version], Document$1.defaultOptions);
   const schema = new Schema.Schema(options);
   return schema.createNode(value, wrapScalars, tag);
 }
-
 class Document extends Document$1.Document {
   constructor(options) {
     super(Object.assign({}, Document$1.defaultOptions, options));
   }
-
 }
-
 function parseAllDocuments(src, options) {
   const stream = [];
   let prev;
-
   for (const cstDoc of parseCst.parse(src)) {
     const doc = new Document(options);
     doc.parse(cstDoc, prev);
     stream.push(doc);
     prev = doc;
   }
-
   return stream;
 }
-
 function parseDocument(src, options) {
   const cst = parseCst.parse(src);
   const doc = new Document(options).parse(cst[0]);
-
   if (cst.length > 1) {
     const errMsg = 'Source contains multiple documents; please use YAML.parseAllDocuments()';
     doc.errors.unshift(new PlainValue.YAMLSemanticError(cst[1], errMsg));
   }
-
   return doc;
 }
-
 function parse(src, options) {
   const doc = parseDocument(src, options);
   doc.warnings.forEach(warning => warnings.warn(warning));
   if (doc.errors.length > 0) throw doc.errors[0];
   return doc.toJSON();
 }
-
 function stringify(value, options) {
   const doc = new Document(options);
   doc.contents = value;
   return String(doc);
 }
-
 const YAML = {
   createNode,
   defaultOptions: Document$1.defaultOptions,
@@ -8817,20 +9240,20 @@ exports.YAML = YAML;
 "use strict";
 
 
-var PlainValue = __nccwpck_require__(1346);
+var PlainValue = __nccwpck_require__(9609);
 
 class BlankLine extends PlainValue.Node {
   constructor() {
     super(PlainValue.Type.BLANK_LINE);
   }
+
   /* istanbul ignore next */
-
-
   get includesTrailingLines() {
     // This is never called from anywhere, but if it were,
     // this is the value it should return.
     return true;
   }
+
   /**
    * Parses a blank line from the source
    *
@@ -8838,14 +9261,11 @@ class BlankLine extends PlainValue.Node {
    * @param {number} start - Index of first \n character
    * @returns {number} - Index of the character after this
    */
-
-
   parse(context, start) {
     this.context = context;
     this.range = new PlainValue.Range(start, start + 1);
     return start + 1;
   }
-
 }
 
 class CollectionItem extends PlainValue.Node {
@@ -8853,17 +9273,15 @@ class CollectionItem extends PlainValue.Node {
     super(type, props);
     this.node = null;
   }
-
   get includesTrailingLines() {
     return !!this.node && this.node.includesTrailingLines;
   }
+
   /**
    * @param {ParseContext} context
    * @param {number} start - Index of first character
    * @returns {number} - Index of the character after this
    */
-
-
   parse(context, start) {
     this.context = context;
     const {
@@ -8881,7 +9299,6 @@ class CollectionItem extends PlainValue.Node {
     const inlineComment = ch === '#';
     const comments = [];
     let blankLine = null;
-
     while (ch === '\n' || ch === '#') {
       if (ch === '#') {
         const end = PlainValue.Node.endOfLine(src, offset + 1);
@@ -8891,20 +9308,16 @@ class CollectionItem extends PlainValue.Node {
         atLineStart = true;
         lineStart = offset + 1;
         const wsEnd = PlainValue.Node.endOfWhiteSpace(src, lineStart);
-
         if (src[wsEnd] === '\n' && comments.length === 0) {
           blankLine = new BlankLine();
           lineStart = blankLine.parse({
             src
           }, lineStart);
         }
-
         offset = PlainValue.Node.endOfIndent(src, lineStart);
       }
-
       ch = src[offset];
     }
-
     if (PlainValue.Node.nextNodeIsIndented(ch, offset - (lineStart + indent), this.type !== PlainValue.Type.SEQ_ITEM)) {
       this.node = parseNode({
         atLineStart,
@@ -8916,7 +9329,6 @@ class CollectionItem extends PlainValue.Node {
     } else if (ch && lineStart > start + 1) {
       offset = lineStart - 1;
     }
-
     if (this.node) {
       if (blankLine) {
         // Only blank lines preceding non-empty nodes are captured. Note that
@@ -8925,7 +9337,6 @@ class CollectionItem extends PlainValue.Node {
         const items = context.parent.items || context.parent.contents;
         if (items) items.push(blankLine);
       }
-
       if (comments.length) Array.prototype.push.apply(this.props, comments);
       offset = this.node.range.end;
     } else {
@@ -8937,17 +9348,14 @@ class CollectionItem extends PlainValue.Node {
         offset = PlainValue.Node.endOfLine(src, start + 1);
       }
     }
-
     const end = this.node ? this.node.valueRange.end : offset;
     this.valueRange = new PlainValue.Range(start, end);
     return offset;
   }
-
   setOrigRanges(cr, offset) {
     offset = super.setOrigRanges(cr, offset);
     return this.node ? this.node.setOrigRanges(cr, offset) : offset;
   }
-
   toString() {
     const {
       context: {
@@ -8961,13 +9369,13 @@ class CollectionItem extends PlainValue.Node {
     const str = node ? src.slice(range.start, node.range.start) + String(node) : src.slice(range.start, range.end);
     return PlainValue.Node.addStringTerminator(src, range.end, str);
   }
-
 }
 
 class Comment extends PlainValue.Node {
   constructor() {
     super(PlainValue.Type.COMMENT);
   }
+
   /**
    * Parses a comment line from the source
    *
@@ -8975,29 +9383,22 @@ class Comment extends PlainValue.Node {
    * @param {number} start - Index of first character
    * @returns {number} - Index of the character after this scalar
    */
-
-
   parse(context, start) {
     this.context = context;
     const offset = this.parseComment(start);
     this.range = new PlainValue.Range(start, offset);
     return offset;
   }
-
 }
 
 function grabCollectionEndComments(node) {
   let cnode = node;
-
   while (cnode instanceof CollectionItem) cnode = cnode.node;
-
   if (!(cnode instanceof Collection)) return null;
   const len = cnode.items.length;
   let ci = -1;
-
   for (let i = len - 1; i >= 0; --i) {
     const n = cnode.items[i];
-
     if (n.type === PlainValue.Type.COMMENT) {
       // Keep sufficiently indented comments with preceding node
       const {
@@ -9008,18 +9409,15 @@ function grabCollectionEndComments(node) {
       ci = i;
     } else if (n.type === PlainValue.Type.BLANK_LINE) ci = i;else break;
   }
-
   if (ci === -1) return null;
   const ca = cnode.items.splice(ci, len - ci);
   const prevEnd = ca[0].range.start;
-
   while (true) {
     cnode.range.end = prevEnd;
     if (cnode.valueRange && cnode.valueRange.end > prevEnd) cnode.valueRange.end = prevEnd;
     if (cnode === node) break;
     cnode = cnode.context.parent;
   }
-
   return ca;
 }
 class Collection extends PlainValue.Node {
@@ -9032,10 +9430,8 @@ class Collection extends PlainValue.Node {
     if (ch !== '#' && ch !== '\n') return false;
     return Collection.nextContentHasIndent(src, offset, indent);
   }
-
   constructor(firstItem) {
     super(firstItem.type === PlainValue.Type.SEQ_ITEM ? PlainValue.Type.SEQ : PlainValue.Type.MAP);
-
     for (let i = firstItem.props.length - 1; i >= 0; --i) {
       if (firstItem.props[i].start < firstItem.context.lineStart) {
         // props on previous line are assumed by the collection
@@ -9046,34 +9442,31 @@ class Collection extends PlainValue.Node {
         break;
       }
     }
-
     this.items = [firstItem];
     const ec = grabCollectionEndComments(firstItem);
     if (ec) Array.prototype.push.apply(this.items, ec);
   }
-
   get includesTrailingLines() {
     return this.items.length > 0;
   }
+
   /**
    * @param {ParseContext} context
    * @param {number} start - Index of first character
    * @returns {number} - Index of the character after this
    */
-
-
   parse(context, start) {
     this.context = context;
     const {
       parseNode,
       src
-    } = context; // It's easier to recalculate lineStart here rather than tracking down the
+    } = context;
+    // It's easier to recalculate lineStart here rather than tracking down the
     // last context from which to read it -- eemeli/yaml#2
-
     let lineStart = PlainValue.Node.startOfLine(src, start);
-    const firstItem = this.items[0]; // First-item context needs to be correct for later comment handling
+    const firstItem = this.items[0];
+    // First-item context needs to be correct for later comment handling
     // -- eemeli/yaml#17
-
     firstItem.context.parent = this;
     this.valueRange = PlainValue.Range.copy(firstItem.valueRange);
     const indent = firstItem.range.start - firstItem.context.lineStart;
@@ -9082,7 +9475,6 @@ class Collection extends PlainValue.Node {
     let ch = src[offset];
     let atLineStart = PlainValue.Node.endOfWhiteSpace(src, lineStart) === offset;
     let prevIncludesTrailingLines = false;
-
     while (ch) {
       while (ch === '\n' || ch === '#') {
         if (atLineStart && ch === '\n' && !prevIncludesTrailingLines) {
@@ -9091,19 +9483,16 @@ class Collection extends PlainValue.Node {
             src
           }, offset);
           this.valueRange.end = offset;
-
           if (offset >= src.length) {
             ch = null;
             break;
           }
-
           this.items.push(blankLine);
           offset -= 1; // blankLine.parse() consumes terminal newline
         } else if (ch === '#') {
           if (offset < lineStart + indent && !Collection.nextContentHasIndent(src, offset, indent)) {
             return offset;
           }
-
           const comment = new Comment();
           offset = comment.parse({
             indent,
@@ -9112,33 +9501,26 @@ class Collection extends PlainValue.Node {
           }, offset);
           this.items.push(comment);
           this.valueRange.end = offset;
-
           if (offset >= src.length) {
             ch = null;
             break;
           }
         }
-
         lineStart = offset + 1;
         offset = PlainValue.Node.endOfIndent(src, lineStart);
-
         if (PlainValue.Node.atBlank(src, offset)) {
           const wsEnd = PlainValue.Node.endOfWhiteSpace(src, offset);
           const next = src[wsEnd];
-
           if (!next || next === '\n' || next === '#') {
             offset = wsEnd;
           }
         }
-
         ch = src[offset];
         atLineStart = true;
       }
-
       if (!ch) {
         break;
       }
-
       if (offset !== lineStart + indent && (atLineStart || ch !== ':')) {
         if (offset < lineStart + indent) {
           if (lineStart > start) offset = lineStart;
@@ -9148,7 +9530,6 @@ class Collection extends PlainValue.Node {
           this.error = new PlainValue.YAMLSyntaxError(this, msg);
         }
       }
-
       if (firstItem.type === PlainValue.Type.SEQ_ITEM) {
         if (ch !== '-') {
           if (lineStart > start) offset = lineStart;
@@ -9157,13 +9538,11 @@ class Collection extends PlainValue.Node {
       } else if (ch === '-' && !this.error) {
         // map key may start with -, as long as it's followed by a non-whitespace char
         const next = src[offset + 1];
-
         if (!next || next === '\n' || next === '\t' || next === ' ') {
           const msg = 'A collection cannot be both a mapping and a sequence';
           this.error = new PlainValue.YAMLSyntaxError(this, msg);
         }
       }
-
       const node = parseNode({
         atLineStart,
         inCollection: true,
@@ -9172,35 +9551,29 @@ class Collection extends PlainValue.Node {
         parent: this
       }, offset);
       if (!node) return offset; // at next document start
-
       this.items.push(node);
       this.valueRange.end = node.valueRange.end;
       offset = PlainValue.Node.normalizeOffset(src, node.range.end);
       ch = src[offset];
       atLineStart = false;
-      prevIncludesTrailingLines = node.includesTrailingLines; // Need to reset lineStart and atLineStart here if preceding node's range
+      prevIncludesTrailingLines = node.includesTrailingLines;
+      // Need to reset lineStart and atLineStart here if preceding node's range
       // has advanced to check the current line's indentation level
       // -- eemeli/yaml#10 & eemeli/yaml#38
-
       if (ch) {
         let ls = offset - 1;
         let prev = src[ls];
-
         while (prev === ' ' || prev === '\t') prev = src[--ls];
-
         if (prev === '\n') {
           lineStart = ls + 1;
           atLineStart = true;
         }
       }
-
       const ec = grabCollectionEndComments(node);
       if (ec) Array.prototype.push.apply(this.items, ec);
     }
-
     return offset;
   }
-
   setOrigRanges(cr, offset) {
     offset = super.setOrigRanges(cr, offset);
     this.items.forEach(node => {
@@ -9208,7 +9581,6 @@ class Collection extends PlainValue.Node {
     });
     return offset;
   }
-
   toString() {
     const {
       context: {
@@ -9220,7 +9592,6 @@ class Collection extends PlainValue.Node {
     } = this;
     if (value != null) return value;
     let str = src.slice(range.start, items[0].range.start) + String(items[0]);
-
     for (let i = 1; i < items.length; ++i) {
       const item = items[i];
       const {
@@ -9230,10 +9601,8 @@ class Collection extends PlainValue.Node {
       if (atLineStart) for (let i = 0; i < indent; ++i) str += ' ';
       str += String(item);
     }
-
     return PlainValue.Node.addStringTerminator(src, range.end, str);
   }
-
 }
 
 class Directive extends PlainValue.Node {
@@ -9241,38 +9610,30 @@ class Directive extends PlainValue.Node {
     super(PlainValue.Type.DIRECTIVE);
     this.name = null;
   }
-
   get parameters() {
     const raw = this.rawValue;
     return raw ? raw.trim().split(/[ \t]+/) : [];
   }
-
   parseName(start) {
     const {
       src
     } = this.context;
     let offset = start;
     let ch = src[offset];
-
     while (ch && ch !== '\n' && ch !== '\t' && ch !== ' ') ch = src[offset += 1];
-
     this.name = src.slice(start, offset);
     return offset;
   }
-
   parseParameters(start) {
     const {
       src
     } = this.context;
     let offset = start;
     let ch = src[offset];
-
     while (ch && ch !== '\n' && ch !== '#') ch = src[offset += 1];
-
     this.valueRange = new PlainValue.Range(start, offset);
     return offset;
   }
-
   parse(context, start) {
     this.context = context;
     let offset = this.parseName(start + 1);
@@ -9281,7 +9642,6 @@ class Directive extends PlainValue.Node {
     this.range = new PlainValue.Range(start, offset);
     return offset;
   }
-
 }
 
 class Document extends PlainValue.Node {
@@ -9290,7 +9650,6 @@ class Document extends PlainValue.Node {
     const ch = src[offset];
     return ch === '#' || ch === '\n' ? offset : start;
   }
-
   constructor() {
     super(PlainValue.Type.DOCUMENT);
     this.directives = null;
@@ -9298,7 +9657,6 @@ class Document extends PlainValue.Node {
     this.directivesEndMarker = null;
     this.documentEndMarker = null;
   }
-
   parseDirectives(start) {
     const {
       src
@@ -9307,10 +9665,8 @@ class Document extends PlainValue.Node {
     let atLineStart = true;
     let hasDirectives = false;
     let offset = start;
-
     while (!PlainValue.Node.atDocumentBoundary(src, offset, PlainValue.Char.DIRECTIVES_END)) {
       offset = Document.startCommentOrEndBlankLine(src, offset);
-
       switch (src[offset]) {
         case '\n':
           if (atLineStart) {
@@ -9318,7 +9674,6 @@ class Document extends PlainValue.Node {
             offset = blankLine.parse({
               src
             }, offset);
-
             if (offset < src.length) {
               this.directives.push(blankLine);
             }
@@ -9326,9 +9681,7 @@ class Document extends PlainValue.Node {
             offset += 1;
             atLineStart = true;
           }
-
           break;
-
         case '#':
           {
             const comment = new Comment();
@@ -9339,7 +9692,6 @@ class Document extends PlainValue.Node {
             atLineStart = false;
           }
           break;
-
         case '%':
           {
             const directive = new Directive();
@@ -9352,7 +9704,6 @@ class Document extends PlainValue.Node {
             atLineStart = false;
           }
           break;
-
         default:
           if (hasDirectives) {
             this.error = new PlainValue.YAMLSemanticError(this, 'Missing directives-end indicator line');
@@ -9360,26 +9711,21 @@ class Document extends PlainValue.Node {
             this.contents = this.directives;
             this.directives = [];
           }
-
           return offset;
       }
     }
-
     if (src[offset]) {
       this.directivesEndMarker = new PlainValue.Range(offset, offset + 3);
       return offset + 3;
     }
-
     if (hasDirectives) {
       this.error = new PlainValue.YAMLSemanticError(this, 'Missing directives-end indicator line');
     } else if (this.directives.length > 0) {
       this.contents = this.directives;
       this.directives = [];
     }
-
     return offset;
   }
-
   parseContents(start) {
     const {
       parseNode,
@@ -9387,13 +9733,10 @@ class Document extends PlainValue.Node {
     } = this.context;
     if (!this.contents) this.contents = [];
     let lineStart = start;
-
     while (src[lineStart - 1] === '-') lineStart -= 1;
-
     let offset = PlainValue.Node.endOfWhiteSpace(src, start);
     let atLineStart = lineStart === start;
     this.valueRange = new PlainValue.Range(offset);
-
     while (!PlainValue.Node.atDocumentBoundary(src, offset, PlainValue.Char.DOCUMENT_END)) {
       switch (src[offset]) {
         case '\n':
@@ -9402,7 +9745,6 @@ class Document extends PlainValue.Node {
             offset = blankLine.parse({
               src
             }, offset);
-
             if (offset < src.length) {
               this.contents.push(blankLine);
             }
@@ -9410,10 +9752,8 @@ class Document extends PlainValue.Node {
             offset += 1;
             atLineStart = true;
           }
-
           lineStart = offset;
           break;
-
         case '#':
           {
             const comment = new Comment();
@@ -9424,7 +9764,6 @@ class Document extends PlainValue.Node {
             atLineStart = false;
           }
           break;
-
         default:
           {
             const iEnd = PlainValue.Node.endOfIndent(src, offset);
@@ -9438,7 +9777,6 @@ class Document extends PlainValue.Node {
             };
             const node = parseNode(context, iEnd);
             if (!node) return this.valueRange.end = iEnd; // at next document start
-
             this.contents.push(node);
             offset = node.range.end;
             atLineStart = false;
@@ -9446,19 +9784,14 @@ class Document extends PlainValue.Node {
             if (ec) Array.prototype.push.apply(this.contents, ec);
           }
       }
-
       offset = Document.startCommentOrEndBlankLine(src, offset);
     }
-
     this.valueRange.end = offset;
-
     if (src[offset]) {
       this.documentEndMarker = new PlainValue.Range(offset, offset + 3);
       offset += 3;
-
       if (src[offset]) {
         offset = PlainValue.Node.endOfWhiteSpace(src, offset);
-
         if (src[offset] === '#') {
           const comment = new Comment();
           offset = comment.parse({
@@ -9466,30 +9799,25 @@ class Document extends PlainValue.Node {
           }, offset);
           this.contents.push(comment);
         }
-
         switch (src[offset]) {
           case '\n':
             offset += 1;
             break;
-
           case undefined:
             break;
-
           default:
             this.error = new PlainValue.YAMLSyntaxError(this, 'Document end marker line cannot have a non-comment suffix');
         }
       }
     }
-
     return offset;
   }
+
   /**
    * @param {ParseContext} context
    * @param {number} start - Index of first character
    * @returns {number} - Index of the character after this
    */
-
-
   parse(context, start) {
     context.root = this;
     this.context = context;
@@ -9497,12 +9825,10 @@ class Document extends PlainValue.Node {
       src
     } = context;
     let offset = src.charCodeAt(start) === 0xfeff ? start + 1 : start; // skip BOM
-
     offset = this.parseDirectives(offset);
     offset = this.parseContents(offset);
     return offset;
   }
-
   setOrigRanges(cr, offset) {
     offset = super.setOrigRanges(cr, offset);
     this.directives.forEach(node => {
@@ -9515,7 +9841,6 @@ class Document extends PlainValue.Node {
     if (this.documentEndMarker) offset = this.documentEndMarker.setOrigRange(cr, offset);
     return offset;
   }
-
   toString() {
     const {
       contents,
@@ -9524,16 +9849,13 @@ class Document extends PlainValue.Node {
     } = this;
     if (value != null) return value;
     let str = directives.join('');
-
     if (contents.length > 0) {
       if (directives.length > 0 || contents[0].type === PlainValue.Type.COMMENT) str += '---\n';
       str += contents.join('');
     }
-
     if (str[str.length - 1] !== '\n') str += '\n';
     return str;
   }
-
 }
 
 class Alias extends PlainValue.Node {
@@ -9555,7 +9877,6 @@ class Alias extends PlainValue.Node {
     offset = this.parseComment(offset);
     return offset;
   }
-
 }
 
 const Chomp = {
@@ -9570,11 +9891,9 @@ class BlockValue extends PlainValue.Node {
     this.chomping = Chomp.CLIP;
     this.header = null;
   }
-
   get includesTrailingLines() {
     return this.chomping === Chomp.KEEP;
   }
-
   get strValue() {
     if (!this.valueRange || !this.context) return null;
     let {
@@ -9588,20 +9907,15 @@ class BlockValue extends PlainValue.Node {
     if (this.valueRange.isEmpty()) return '';
     let lastNewLine = null;
     let ch = src[end - 1];
-
     while (ch === '\n' || ch === '\t' || ch === ' ') {
       end -= 1;
-
       if (end <= start) {
         if (this.chomping === Chomp.KEEP) break;else return ''; // probably never happens
       }
-
       if (ch === '\n') lastNewLine = end;
       ch = src[end - 1];
     }
-
     let keepStart = end + 1;
-
     if (lastNewLine) {
       if (this.chomping === Chomp.KEEP) {
         keepStart = lastNewLine;
@@ -9610,33 +9924,27 @@ class BlockValue extends PlainValue.Node {
         end = lastNewLine;
       }
     }
-
     const bi = indent + this.blockIndent;
     const folded = this.type === PlainValue.Type.BLOCK_FOLDED;
     let atStart = true;
     let str = '';
     let sep = '';
     let prevMoreIndented = false;
-
     for (let i = start; i < end; ++i) {
       for (let j = 0; j < bi; ++j) {
         if (src[i] !== ' ') break;
         i += 1;
       }
-
       const ch = src[i];
-
       if (ch === '\n') {
         if (sep === '\n') str += '\n';else sep = '\n';
       } else {
         const lineEnd = PlainValue.Node.endOfLine(src, i);
         const line = src.slice(i, lineEnd);
         i = lineEnd;
-
         if (folded && (ch === ' ' || ch === '\t') && i < keepStart) {
           if (sep === ' ') sep = '\n';else if (!prevMoreIndented && !atStart && sep === '\n') sep = '\n\n';
           str += sep + line; //+ ((lineEnd < end && src[lineEnd]) || '')
-
           sep = lineEnd < end && src[lineEnd] || '';
           prevMoreIndented = true;
         } else {
@@ -9644,33 +9952,26 @@ class BlockValue extends PlainValue.Node {
           sep = folded && i < keepStart ? ' ' : '\n';
           prevMoreIndented = false;
         }
-
         if (atStart && line !== '') atStart = false;
       }
     }
-
     return this.chomping === Chomp.STRIP ? str : str + '\n';
   }
-
   parseBlockHeader(start) {
     const {
       src
     } = this.context;
     let offset = start + 1;
     let bi = '';
-
     while (true) {
       const ch = src[offset];
-
       switch (ch) {
         case '-':
           this.chomping = Chomp.STRIP;
           break;
-
         case '+':
           this.chomping = Chomp.KEEP;
           break;
-
         case '0':
         case '1':
         case '2':
@@ -9683,17 +9984,14 @@ class BlockValue extends PlainValue.Node {
         case '9':
           bi += ch;
           break;
-
         default:
           this.blockIndent = Number(bi) || null;
           this.header = new PlainValue.Range(start, offset);
           return offset;
       }
-
       offset += 1;
     }
   }
-
   parseBlockValue(start) {
     const {
       indent,
@@ -9703,16 +10001,13 @@ class BlockValue extends PlainValue.Node {
     let offset = start;
     let valueEnd = start;
     let minBlockIndent = 1;
-
     for (let ch = src[offset]; ch === '\n'; ch = src[offset]) {
       offset += 1;
       if (PlainValue.Node.atDocumentBoundary(src, offset)) break;
       const end = PlainValue.Node.endOfBlockIndent(src, indent, offset); // should not include tab?
-
       if (end === null) break;
       const ch = src[end];
       const lineIndent = end - (offset + indent);
-
       if (!this.blockIndent) {
         // no explicit block indent, none yet detected
         if (src[end] !== '\n') {
@@ -9721,7 +10016,6 @@ class BlockValue extends PlainValue.Node {
             const msg = 'Block scalars with more-indented leading empty lines must use an explicit indentation indicator';
             this.error = new PlainValue.YAMLSemanticError(this, msg);
           }
-
           this.blockIndent = lineIndent;
         } else if (lineIndent > minBlockIndent) {
           // empty line with more whitespace
@@ -9729,28 +10023,25 @@ class BlockValue extends PlainValue.Node {
         }
       } else if (ch && ch !== '\n' && lineIndent < this.blockIndent) {
         if (src[end] === '#') break;
-
         if (!this.error) {
           const src = explicit ? 'explicit indentation indicator' : 'first line';
           const msg = `Block scalars must not be less indented than their ${src}`;
           this.error = new PlainValue.YAMLSemanticError(this, msg);
         }
       }
-
       if (src[end] === '\n') {
         offset = end;
       } else {
         offset = valueEnd = PlainValue.Node.endOfLine(src, end);
       }
     }
-
     if (this.chomping !== Chomp.KEEP) {
       offset = src[valueEnd] ? valueEnd + 1 : valueEnd;
     }
-
     this.valueRange = new PlainValue.Range(start + 1, offset);
     return offset;
   }
+
   /**
    * Parses a block value from the source
    *
@@ -9771,8 +10062,6 @@ class BlockValue extends PlainValue.Node {
    * @param {number} start - Index of first character
    * @returns {number} - Index of the character after this block
    */
-
-
   parse(context, start) {
     this.context = context;
     const {
@@ -9784,12 +10073,10 @@ class BlockValue extends PlainValue.Node {
     offset = this.parseBlockValue(offset);
     return offset;
   }
-
   setOrigRanges(cr, offset) {
     offset = super.setOrigRanges(cr, offset);
     return this.header ? this.header.setOrigRange(cr, offset) : offset;
   }
-
 }
 
 class FlowCollection extends PlainValue.Node {
@@ -9797,18 +10084,16 @@ class FlowCollection extends PlainValue.Node {
     super(type, props);
     this.items = null;
   }
-
   prevNodeIsJsonLike(idx = this.items.length) {
     const node = this.items[idx - 1];
     return !!node && (node.jsonLike || node.type === PlainValue.Type.COMMENT && this.prevNodeIsJsonLike(idx - 1));
   }
+
   /**
    * @param {ParseContext} context
    * @param {number} start - Index of first character
    * @returns {number} - Index of the character after this
    */
-
-
   parse(context, start) {
     this.context = context;
     const {
@@ -9820,21 +10105,18 @@ class FlowCollection extends PlainValue.Node {
       lineStart
     } = context;
     let char = src[start]; // { or [
-
     this.items = [{
       char,
       offset: start
     }];
     let offset = PlainValue.Node.endOfWhiteSpace(src, start + 1);
     char = src[offset];
-
     while (char && char !== ']' && char !== '}') {
       switch (char) {
         case '\n':
           {
             lineStart = offset + 1;
             const wsEnd = PlainValue.Node.endOfWhiteSpace(src, lineStart);
-
             if (src[wsEnd] === '\n') {
               const blankLine = new BlankLine();
               lineStart = blankLine.parse({
@@ -9842,12 +10124,9 @@ class FlowCollection extends PlainValue.Node {
               }, lineStart);
               this.items.push(blankLine);
             }
-
             offset = PlainValue.Node.endOfIndent(src, lineStart);
-
             if (offset <= lineStart + indent) {
               char = src[offset];
-
               if (offset < lineStart + indent || char !== ']' && char !== '}') {
                 const msg = 'Insufficient indentation in flow collection';
                 this.error = new PlainValue.YAMLSemanticError(this, msg);
@@ -9855,7 +10134,6 @@ class FlowCollection extends PlainValue.Node {
             }
           }
           break;
-
         case ',':
           {
             this.items.push({
@@ -9865,7 +10143,6 @@ class FlowCollection extends PlainValue.Node {
             offset += 1;
           }
           break;
-
         case '#':
           {
             const comment = new Comment();
@@ -9875,13 +10152,12 @@ class FlowCollection extends PlainValue.Node {
             this.items.push(comment);
           }
           break;
-
         case '?':
         case ':':
           {
             const next = src[offset + 1];
-
-            if (next === '\n' || next === '\t' || next === ' ' || next === ',' || // in-flow : after JSON-like key does not need to be followed by whitespace
+            if (next === '\n' || next === '\t' || next === ' ' || next === ',' ||
+            // in-flow : after JSON-like key does not need to be followed by whitespace
             char === ':' && this.prevNodeIsJsonLike()) {
               this.items.push({
                 char,
@@ -9892,7 +10168,6 @@ class FlowCollection extends PlainValue.Node {
             }
           }
         // fallthrough
-
         default:
           {
             const node = parseNode({
@@ -9903,24 +10178,19 @@ class FlowCollection extends PlainValue.Node {
               lineStart,
               parent: this
             }, offset);
-
             if (!node) {
               // at next document start
               this.valueRange = new PlainValue.Range(start, offset);
               return offset;
             }
-
             this.items.push(node);
             offset = PlainValue.Node.normalizeOffset(src, node.range.end);
           }
       }
-
       offset = PlainValue.Node.endOfWhiteSpace(src, offset);
       char = src[offset];
     }
-
     this.valueRange = new PlainValue.Range(start, offset + 1);
-
     if (char) {
       this.items.push({
         char,
@@ -9929,10 +10199,8 @@ class FlowCollection extends PlainValue.Node {
       offset = PlainValue.Node.endOfWhiteSpace(src, offset + 1);
       offset = this.parseComment(offset);
     }
-
     return offset;
   }
-
   setOrigRanges(cr, offset) {
     offset = super.setOrigRanges(cr, offset);
     this.items.forEach(node => {
@@ -9942,18 +10210,15 @@ class FlowCollection extends PlainValue.Node {
         node.origOffset = node.offset;
       } else {
         let i = offset;
-
         while (i < cr.length) {
           if (cr[i] > node.offset) break;else ++i;
         }
-
         node.origOffset = node.offset + i;
         offset = i;
       }
     });
     return offset;
   }
-
   toString() {
     const {
       context: {
@@ -9971,7 +10236,6 @@ class FlowCollection extends PlainValue.Node {
       const prefix = src.slice(prevEnd, node.range.start);
       prevEnd = node.range.end;
       str += prefix + String(node);
-
       if (str[str.length - 1] === '\n' && src[prevEnd - 1] !== '\n' && src[prevEnd] === '\n') {
         // Comment range does not include the terminal newline, but its
         // stringified value does. Without this fix, newlines at comment ends
@@ -9982,25 +10246,21 @@ class FlowCollection extends PlainValue.Node {
     str += src.slice(prevEnd, range.end);
     return PlainValue.Node.addStringTerminator(src, range.end, str);
   }
-
 }
 
 class QuoteDouble extends PlainValue.Node {
   static endOfQuote(src, offset) {
     let ch = src[offset];
-
     while (ch && ch !== '"') {
       offset += ch === '\\' ? 2 : 1;
       ch = src[offset];
     }
-
     return offset + 1;
   }
+
   /**
    * @returns {string | { str: string, errors: YAMLSyntaxError[] }}
    */
-
-
   get strValue() {
     if (!this.valueRange || !this.context) return null;
     const errors = [];
@@ -10012,14 +10272,12 @@ class QuoteDouble extends PlainValue.Node {
       indent,
       src
     } = this.context;
-    if (src[end - 1] !== '"') errors.push(new PlainValue.YAMLSyntaxError(this, 'Missing closing "quote')); // Using String#replace is too painful with escaped newlines preceded by
+    if (src[end - 1] !== '"') errors.push(new PlainValue.YAMLSyntaxError(this, 'Missing closing "quote'));
+    // Using String#replace is too painful with escaped newlines preceded by
     // escaped backslashes; also, this should be faster.
-
     let str = '';
-
     for (let i = start + 1; i < end - 1; ++i) {
       const ch = src[i];
-
       if (ch === '\n') {
         if (PlainValue.Node.atDocumentBoundary(src, i + 1)) errors.push(new PlainValue.YAMLSemanticError(this, 'Document boundary indicators are not allowed within string values'));
         const {
@@ -10032,114 +10290,90 @@ class QuoteDouble extends PlainValue.Node {
         if (error) errors.push(new PlainValue.YAMLSemanticError(this, 'Multi-line double-quoted string needs to be sufficiently indented'));
       } else if (ch === '\\') {
         i += 1;
-
         switch (src[i]) {
           case '0':
             str += '\0';
             break;
           // null character
-
           case 'a':
             str += '\x07';
             break;
           // bell character
-
           case 'b':
             str += '\b';
             break;
           // backspace
-
           case 'e':
             str += '\x1b';
             break;
           // escape character
-
           case 'f':
             str += '\f';
             break;
           // form feed
-
           case 'n':
             str += '\n';
             break;
           // line feed
-
           case 'r':
             str += '\r';
             break;
           // carriage return
-
           case 't':
             str += '\t';
             break;
           // horizontal tab
-
           case 'v':
             str += '\v';
             break;
           // vertical tab
-
           case 'N':
             str += '\u0085';
             break;
           // Unicode next line
-
           case '_':
             str += '\u00a0';
             break;
           // Unicode non-breaking space
-
           case 'L':
             str += '\u2028';
             break;
           // Unicode line separator
-
           case 'P':
             str += '\u2029';
             break;
           // Unicode paragraph separator
-
           case ' ':
             str += ' ';
             break;
-
           case '"':
             str += '"';
             break;
-
           case '/':
             str += '/';
             break;
-
           case '\\':
             str += '\\';
             break;
-
           case '\t':
             str += '\t';
             break;
-
           case 'x':
             str += this.parseCharCode(i + 1, 2, errors);
             i += 2;
             break;
-
           case 'u':
             str += this.parseCharCode(i + 1, 4, errors);
             i += 4;
             break;
-
           case 'U':
             str += this.parseCharCode(i + 1, 8, errors);
             i += 8;
             break;
-
           case '\n':
             // skip escaped newlines, but still trim the following line
             while (src[i + 1] === ' ' || src[i + 1] === '\t') i += 1;
-
             break;
-
           default:
             errors.push(new PlainValue.YAMLSyntaxError(this, `Invalid escape sequence ${src.substr(i - 1, 2)}`));
             str += '\\' + src[i];
@@ -10148,24 +10382,20 @@ class QuoteDouble extends PlainValue.Node {
         // trim trailing whitespace
         const wsStart = i;
         let next = src[i + 1];
-
         while (next === ' ' || next === '\t') {
           i += 1;
           next = src[i + 1];
         }
-
         if (next !== '\n') str += i > wsStart ? src.slice(wsStart, i + 1) : ch;
       } else {
         str += ch;
       }
     }
-
     return errors.length > 0 ? {
       errors,
       str
     } : str;
   }
-
   parseCharCode(offset, length, errors) {
     const {
       src
@@ -10173,14 +10403,13 @@ class QuoteDouble extends PlainValue.Node {
     const cc = src.substr(offset, length);
     const ok = cc.length === length && /^[0-9a-fA-F]+$/.test(cc);
     const code = ok ? parseInt(cc, 16) : NaN;
-
     if (isNaN(code)) {
       errors.push(new PlainValue.YAMLSyntaxError(this, `Invalid escape sequence ${src.substr(offset - 2, length + 2)}`));
       return src.substr(offset - 2, length + 2);
     }
-
     return String.fromCodePoint(code);
   }
+
   /**
    * Parses a "double quoted" value from the source
    *
@@ -10188,8 +10417,6 @@ class QuoteDouble extends PlainValue.Node {
    * @param {number} start - Index of first character
    * @returns {number} - Index of the character after this scalar
    */
-
-
   parse(context, start) {
     this.context = context;
     const {
@@ -10201,13 +10428,11 @@ class QuoteDouble extends PlainValue.Node {
     offset = this.parseComment(offset);
     return offset;
   }
-
 }
 
 class QuoteSingle extends PlainValue.Node {
   static endOfQuote(src, offset) {
     let ch = src[offset];
-
     while (ch) {
       if (ch === "'") {
         if (src[offset + 1] !== "'") break;
@@ -10216,14 +10441,12 @@ class QuoteSingle extends PlainValue.Node {
         ch = src[offset += 1];
       }
     }
-
     return offset + 1;
   }
+
   /**
    * @returns {string | { str: string, errors: YAMLSyntaxError[] }}
    */
-
-
   get strValue() {
     if (!this.valueRange || !this.context) return null;
     const errors = [];
@@ -10237,10 +10460,8 @@ class QuoteSingle extends PlainValue.Node {
     } = this.context;
     if (src[end - 1] !== "'") errors.push(new PlainValue.YAMLSyntaxError(this, "Missing closing 'quote"));
     let str = '';
-
     for (let i = start + 1; i < end - 1; ++i) {
       const ch = src[i];
-
       if (ch === '\n') {
         if (PlainValue.Node.atDocumentBoundary(src, i + 1)) errors.push(new PlainValue.YAMLSemanticError(this, 'Document boundary indicators are not allowed within string values'));
         const {
@@ -10259,23 +10480,21 @@ class QuoteSingle extends PlainValue.Node {
         // trim trailing whitespace
         const wsStart = i;
         let next = src[i + 1];
-
         while (next === ' ' || next === '\t') {
           i += 1;
           next = src[i + 1];
         }
-
         if (next !== '\n') str += i > wsStart ? src.slice(wsStart, i + 1) : ch;
       } else {
         str += ch;
       }
     }
-
     return errors.length > 0 ? {
       errors,
       str
     } : str;
   }
+
   /**
    * Parses a 'single quoted' value from the source
    *
@@ -10283,8 +10502,6 @@ class QuoteSingle extends PlainValue.Node {
    * @param {number} start - Index of first character
    * @returns {number} - Index of the character after this scalar
    */
-
-
   parse(context, start) {
     this.context = context;
     const {
@@ -10296,44 +10513,36 @@ class QuoteSingle extends PlainValue.Node {
     offset = this.parseComment(offset);
     return offset;
   }
-
 }
 
 function createNewNode(type, props) {
   switch (type) {
     case PlainValue.Type.ALIAS:
       return new Alias(type, props);
-
     case PlainValue.Type.BLOCK_FOLDED:
     case PlainValue.Type.BLOCK_LITERAL:
       return new BlockValue(type, props);
-
     case PlainValue.Type.FLOW_MAP:
     case PlainValue.Type.FLOW_SEQ:
       return new FlowCollection(type, props);
-
     case PlainValue.Type.MAP_KEY:
     case PlainValue.Type.MAP_VALUE:
     case PlainValue.Type.SEQ_ITEM:
       return new CollectionItem(type, props);
-
     case PlainValue.Type.COMMENT:
     case PlainValue.Type.PLAIN:
       return new PlainValue.PlainValue(type, props);
-
     case PlainValue.Type.QUOTE_DOUBLE:
       return new QuoteDouble(type, props);
-
     case PlainValue.Type.QUOTE_SINGLE:
       return new QuoteSingle(type, props);
-
     /* istanbul ignore next */
-
     default:
       return null;
     // should never happen
   }
 }
+
 /**
  * @param {boolean} atLineStart - Node starts at beginning of line
  * @param {boolean} inFlow - true if currently in a flow context
@@ -10343,46 +10552,33 @@ function createNewNode(type, props) {
  * @param {Node} parent - The parent of the node
  * @param {string} src - Source of the YAML document
  */
-
-
 class ParseContext {
   static parseType(src, offset, inFlow) {
     switch (src[offset]) {
       case '*':
         return PlainValue.Type.ALIAS;
-
       case '>':
         return PlainValue.Type.BLOCK_FOLDED;
-
       case '|':
         return PlainValue.Type.BLOCK_LITERAL;
-
       case '{':
         return PlainValue.Type.FLOW_MAP;
-
       case '[':
         return PlainValue.Type.FLOW_SEQ;
-
       case '?':
         return !inFlow && PlainValue.Node.atBlank(src, offset + 1, true) ? PlainValue.Type.MAP_KEY : PlainValue.Type.PLAIN;
-
       case ':':
         return !inFlow && PlainValue.Node.atBlank(src, offset + 1, true) ? PlainValue.Type.MAP_VALUE : PlainValue.Type.PLAIN;
-
       case '-':
         return !inFlow && PlainValue.Node.atBlank(src, offset + 1, true) ? PlainValue.Type.SEQ_ITEM : PlainValue.Type.PLAIN;
-
       case '"':
         return PlainValue.Type.QUOTE_DOUBLE;
-
       case "'":
         return PlainValue.Type.QUOTE_SINGLE;
-
       default:
         return PlainValue.Type.PLAIN;
     }
   }
-
   constructor(orig = {}, {
     atLineStart,
     inCollection,
@@ -10391,6 +10587,12 @@ class ParseContext {
     lineStart,
     parent
   } = {}) {
+    /**
+     * Parses a node from the source
+     * @param {ParseContext} overlay
+     * @param {number} start - Index of first non-whitespace character for the node
+     * @returns {?Node} - null if at a document boundary
+     */
     PlainValue._defineProperty(this, "parseNode", (overlay, start) => {
       if (PlainValue.Node.atDocumentBoundary(this.src, start)) return null;
       const context = new ParseContext(this, overlay);
@@ -10400,33 +10602,34 @@ class ParseContext {
         valueStart
       } = context.parseProps(start);
       const node = createNewNode(type, props);
-      let offset = node.parse(context, valueStart);
+      let offset = start;
+      try {
+        offset = node.parse(context, valueStart);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (!node.error) node.error = new PlainValue.YAMLSyntaxError(node, msg);
+      }
       node.range = new PlainValue.Range(start, offset);
       /* istanbul ignore if */
-
       if (offset <= start) {
         // This should never happen, but if it does, let's make sure to at least
         // step one character forward to avoid a busy loop.
-        node.error = new Error(`Node#parse consumed no characters`);
+        if (!node.error) node.error = new Error(`Node#parse consumed no characters`);
         node.error.parseEnd = offset;
         node.error.source = node;
         node.range.end = start + 1;
       }
-
       if (context.nodeStartsCollection(node)) {
         if (!node.error && !context.atLineStart && context.parent.type === PlainValue.Type.DOCUMENT) {
           node.error = new PlainValue.YAMLSyntaxError(node, 'Block collection must not have preceding content here (e.g. directives-end indicator)');
         }
-
         const collection = new Collection(node);
         offset = collection.parse(new ParseContext(context), offset);
         collection.range = new PlainValue.Range(start, offset);
         return collection;
       }
-
       return node;
     });
-
     this.atLineStart = atLineStart != null ? atLineStart : orig.atLineStart || false;
     this.inCollection = inCollection != null ? inCollection : orig.inCollection || false;
     this.inFlow = inFlow != null ? inFlow : orig.inFlow || false;
@@ -10436,7 +10639,6 @@ class ParseContext {
     this.root = orig.root;
     this.src = orig.src;
   }
-
   nodeStartsCollection(node) {
     const {
       inCollection,
@@ -10444,16 +10646,16 @@ class ParseContext {
       src
     } = this;
     if (inCollection || inFlow) return false;
-    if (node instanceof CollectionItem) return true; // check for implicit key
-
+    if (node instanceof CollectionItem) return true;
+    // check for implicit key
     let offset = node.range.end;
     if (src[offset] === '\n' || src[offset - 1] === '\n') return false;
     offset = PlainValue.Node.endOfWhiteSpace(src, offset);
     return src[offset] === ':';
-  } // Anchor and tag are before type, which determines the node implementation
+  }
+
+  // Anchor and tag are before type, which determines the node implementation
   // class; hence this intermediate step.
-
-
   parseProps(offset) {
     const {
       inFlow,
@@ -10464,17 +10666,14 @@ class ParseContext {
     let lineHasProps = false;
     offset = this.atLineStart ? PlainValue.Node.endOfIndent(src, offset) : PlainValue.Node.endOfWhiteSpace(src, offset);
     let ch = src[offset];
-
     while (ch === PlainValue.Char.ANCHOR || ch === PlainValue.Char.COMMENT || ch === PlainValue.Char.TAG || ch === '\n') {
       if (ch === '\n') {
         let inEnd = offset;
         let lineStart;
-
         do {
           lineStart = inEnd + 1;
           inEnd = PlainValue.Node.endOfIndent(src, lineStart);
         } while (src[inEnd] === '\n');
-
         const indentDiff = inEnd - (lineStart + this.indent);
         const noIndicatorAsIndent = parent.type === PlainValue.Type.SEQ_ITEM && parent.context.atLineStart;
         if (src[inEnd] !== '#' && !PlainValue.Node.nextNodeIsIndented(src[inEnd], indentDiff, !noIndicatorAsIndent)) break;
@@ -10488,7 +10687,6 @@ class ParseContext {
         offset = end;
       } else {
         let end = PlainValue.Node.endOfIdentifier(src, offset + 1);
-
         if (ch === PlainValue.Char.TAG && src[end] === ',' && /^[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+,\d\d\d\d(-\d\d){0,2}\/\S/.test(src.slice(offset + 1, end + 13))) {
           // Let's presume we're dealing with a YAML 1.0 domain tag here, rather
           // than an empty but 'foo.bar' private-tagged node in a flow collection
@@ -10496,16 +10694,13 @@ class ParseContext {
           // or date divided by something.
           end = PlainValue.Node.endOfIdentifier(src, end + 5);
         }
-
         props.push(new PlainValue.Range(offset, end));
         lineHasProps = true;
         offset = PlainValue.Node.endOfWhiteSpace(src, end);
       }
-
       ch = src[offset];
-    } // '- &a : b' has an anchor on an empty node
-
-
+    }
+    // '- &a : b' has an anchor on an empty node
     if (lineHasProps && ch === ':' && PlainValue.Node.atBlank(src, offset + 1, true)) offset -= 1;
     const type = ParseContext.parseType(src, offset, inFlow);
     return {
@@ -10514,30 +10709,19 @@ class ParseContext {
       valueStart: offset
     };
   }
-  /**
-   * Parses a node from the source
-   * @param {ParseContext} overlay
-   * @param {number} start - Index of first non-whitespace character for the node
-   * @returns {?Node} - null if at a document boundary
-   */
-
-
 }
 
 // Published as 'yaml/parse-cst'
 function parse(src) {
   const cr = [];
-
   if (src.indexOf('\r') !== -1) {
     src = src.replace(/\r\n?/g, (match, offset) => {
       if (match.length > 1) cr.push(offset);
       return '\n';
     });
   }
-
   const documents = [];
   let offset = 0;
-
   do {
     const doc = new Document();
     const context = new ParseContext({
@@ -10546,24 +10730,17 @@ function parse(src) {
     offset = doc.parse(context, offset);
     documents.push(doc);
   } while (offset < src.length);
-
   documents.setOrigRanges = () => {
     if (cr.length === 0) return false;
-
     for (let i = 1; i < cr.length; ++i) cr[i] -= i;
-
     let crOffset = 0;
-
     for (let i = 0; i < documents.length; ++i) {
       crOffset = documents[i].setOrigRanges(cr, crOffset);
     }
-
     cr.splice(0, cr.length);
     return true;
   };
-
   documents.toString = () => documents.join('...\n');
-
   return documents;
 }
 
@@ -10572,13 +10749,13 @@ exports.parse = parse;
 
 /***/ }),
 
-/***/ 1011:
+/***/ 9091:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var PlainValue = __nccwpck_require__(1346);
+var PlainValue = __nccwpck_require__(9609);
 
 function addCommentBefore(str, indent, comment) {
   if (!comment) return str;
@@ -10593,7 +10770,6 @@ class Node {}
 
 function toJSON(value, arg, ctx) {
   if (Array.isArray(value)) return value.map((v, i) => toJSON(v, String(i), ctx));
-
   if (value && typeof value.toJSON === 'function') {
     const anchor = ctx && ctx.anchors && ctx.anchors.get(value);
     if (anchor) ctx.onCreate = res => {
@@ -10604,7 +10780,6 @@ function toJSON(value, arg, ctx) {
     if (anchor && ctx.onCreate) ctx.onCreate(res);
     return res;
   }
-
   if ((!ctx || !ctx.keep) && typeof value === 'bigint') return Number(value);
   return value;
 }
@@ -10614,23 +10789,18 @@ class Scalar extends Node {
     super();
     this.value = value;
   }
-
   toJSON(arg, ctx) {
     return ctx && ctx.keep ? this.value : toJSON(this.value, arg, ctx);
   }
-
   toString() {
     return String(this.value);
   }
-
 }
 
 function collectionFromPath(schema, path, value) {
   let v = value;
-
   for (let i = path.length - 1; i >= 0; --i) {
     const k = path[i];
-
     if (Number.isInteger(k) && k >= 0) {
       const a = [];
       a[k] = v;
@@ -10646,21 +10816,17 @@ function collectionFromPath(schema, path, value) {
       v = o;
     }
   }
-
   return schema.createNode(v, false);
-} // null, undefined, or an empty non-string iterable (e.g. [])
+}
 
-
+// null, undefined, or an empty non-string iterable (e.g. [])
 const isEmptyPath = path => path == null || typeof path === 'object' && path[Symbol.iterator]().next().done;
 class Collection extends Node {
   constructor(schema) {
     super();
-
     PlainValue._defineProperty(this, "items", []);
-
     this.schema = schema;
   }
-
   addIn(path, value) {
     if (isEmptyPath(path)) this.add(value);else {
       const [key, ...rest] = path;
@@ -10668,18 +10834,15 @@ class Collection extends Node {
       if (node instanceof Collection) node.addIn(rest, value);else if (node === undefined && this.schema) this.set(key, collectionFromPath(this.schema, rest, value));else throw new Error(`Expected YAML collection at ${key}. Remaining path: ${rest}`);
     }
   }
-
   deleteIn([key, ...rest]) {
     if (rest.length === 0) return this.delete(key);
     const node = this.get(key, true);
     if (node instanceof Collection) return node.deleteIn(rest);else throw new Error(`Expected YAML collection at ${key}. Remaining path: ${rest}`);
   }
-
   getIn([key, ...rest], keepScalar) {
     const node = this.get(key, true);
     if (rest.length === 0) return !keepScalar && node instanceof Scalar ? node.value : node;else return node instanceof Collection ? node.getIn(rest, keepScalar) : undefined;
   }
-
   hasAllNullValues() {
     return this.items.every(node => {
       if (!node || node.type !== 'PAIR') return false;
@@ -10687,13 +10850,11 @@ class Collection extends Node {
       return n == null || n instanceof Scalar && n.value == null && !n.commentBefore && !n.comment && !n.tag;
     });
   }
-
   hasIn([key, ...rest]) {
     if (rest.length === 0) return this.has(key);
     const node = this.get(key, true);
     return node instanceof Collection ? node.hasIn(rest) : false;
   }
-
   setIn([key, ...rest], value) {
     if (rest.length === 0) {
       this.set(key, value);
@@ -10701,15 +10862,13 @@ class Collection extends Node {
       const node = this.get(key, true);
       if (node instanceof Collection) node.setIn(rest, value);else if (node === undefined && this.schema) this.set(key, collectionFromPath(this.schema, rest, value));else throw new Error(`Expected YAML collection at ${key}. Remaining path: ${rest}`);
     }
-  } // overridden in implementations
+  }
 
+  // overridden in implementations
   /* istanbul ignore next */
-
-
   toJSON() {
     return null;
   }
-
   toString(ctx, {
     blockItem,
     flowChars,
@@ -10734,7 +10893,6 @@ class Collection extends Node {
     let hasItemWithNewLine = false;
     const nodes = this.items.reduce((nodes, item, i) => {
       let comment;
-
       if (item) {
         if (!chompKeep && item.spaceBefore) nodes.push({
           type: 'comment',
@@ -10749,7 +10907,6 @@ class Collection extends Node {
         if (item.comment) comment = item.comment;
         if (inFlow && (!chompKeep && item.spaceBefore || item.commentBefore || item.comment || item.key && (item.key.commentBefore || item.key.comment) || item.value && (item.value.commentBefore || item.value.comment))) hasItemWithNewLine = true;
       }
-
       chompKeep = false;
       let str = stringify(item, ctx, () => comment = null, () => chompKeep = true);
       if (inFlow && !hasItemWithNewLine && str.includes('\n')) hasItemWithNewLine = true;
@@ -10763,7 +10920,6 @@ class Collection extends Node {
       return nodes;
     }, []);
     let str;
-
     if (nodes.length === 0) {
       str = flowChars.start + flowChars.end;
     } else if (inFlow) {
@@ -10772,14 +10928,11 @@ class Collection extends Node {
         end
       } = flowChars;
       const strings = nodes.map(n => n.str);
-
       if (hasItemWithNewLine || strings.reduce((sum, str) => sum + str.length + 2, 2) > Collection.maxFlowStringSingleLineLength) {
         str = start;
-
         for (const s of strings) {
           str += s ? `\n${indentStep}${indent}${s}` : '\n';
         }
-
         str += `\n${indent}${end}`;
       } else {
         str = `${start} ${strings.join(' ')} ${end}`;
@@ -10787,20 +10940,15 @@ class Collection extends Node {
     } else {
       const strings = nodes.map(blockItem);
       str = strings.shift();
-
       for (const s of strings) str += s ? `\n${indent}${s}` : '\n';
     }
-
     if (this.comment) {
       str += '\n' + this.comment.replace(/^/gm, `${indent}#`);
       if (onComment) onComment();
     } else if (chompKeep && onChompKeep) onChompKeep();
-
     return str;
   }
-
 }
-
 PlainValue._defineProperty(Collection, "maxFlowStringSingleLineLength", 60);
 
 function asItemIndex(key) {
@@ -10808,47 +10956,38 @@ function asItemIndex(key) {
   if (idx && typeof idx === 'string') idx = Number(idx);
   return Number.isInteger(idx) && idx >= 0 ? idx : null;
 }
-
 class YAMLSeq extends Collection {
   add(value) {
     this.items.push(value);
   }
-
   delete(key) {
     const idx = asItemIndex(key);
     if (typeof idx !== 'number') return false;
     const del = this.items.splice(idx, 1);
     return del.length > 0;
   }
-
   get(key, keepScalar) {
     const idx = asItemIndex(key);
     if (typeof idx !== 'number') return undefined;
     const it = this.items[idx];
     return !keepScalar && it instanceof Scalar ? it.value : it;
   }
-
   has(key) {
     const idx = asItemIndex(key);
     return typeof idx === 'number' && idx < this.items.length;
   }
-
   set(key, value) {
     const idx = asItemIndex(key);
     if (typeof idx !== 'number') throw new Error(`Expected a valid index, not ${key}.`);
     this.items[idx] = value;
   }
-
   toJSON(_, ctx) {
     const seq = [];
     if (ctx && ctx.onCreate) ctx.onCreate(seq);
     let i = 0;
-
     for (const item of this.items) seq.push(toJSON(item, String(i++), ctx));
-
     return seq;
   }
-
   toString(ctx, onComment, onChompKeep) {
     if (!ctx) return JSON.stringify(this);
     return super.toString(ctx, {
@@ -10861,7 +11000,6 @@ class YAMLSeq extends Collection {
       itemIndent: (ctx.indent || '') + '  '
     }, onComment, onChompKeep);
   }
-
 }
 
 const stringifyKey = (key, jsKey, ctx) => {
@@ -10878,7 +11016,6 @@ const stringifyKey = (key, jsKey, ctx) => {
   });
   return JSON.stringify(jsKey);
 };
-
 class Pair extends Node {
   constructor(key, value = null) {
     super();
@@ -10886,11 +11023,9 @@ class Pair extends Node {
     this.value = value;
     this.type = Pair.Type.PAIR;
   }
-
   get commentBefore() {
     return this.key instanceof Node ? this.key.commentBefore : undefined;
   }
-
   set commentBefore(cb) {
     if (this.key == null) this.key = new Scalar(null);
     if (this.key instanceof Node) this.key.commentBefore = cb;else {
@@ -10898,10 +11033,8 @@ class Pair extends Node {
       throw new Error(msg);
     }
   }
-
   addToJSMap(ctx, map) {
     const key = toJSON(this.key, '', ctx);
-
     if (map instanceof Map) {
       const value = toJSON(this.value, key, ctx);
       map.set(key, value);
@@ -10917,15 +11050,12 @@ class Pair extends Node {
         configurable: true
       });else map[stringKey] = value;
     }
-
     return map;
   }
-
   toJSON(_, ctx) {
     const pair = ctx && ctx.mapAsMap ? new Map() : {};
     return this.addToJSMap(ctx, pair);
   }
-
   toString(ctx, onComment, onChompKeep) {
     if (!ctx || !ctx.doc) return JSON.stringify(this);
     const {
@@ -10938,18 +11068,15 @@ class Pair extends Node {
       value
     } = this;
     let keyComment = key instanceof Node && key.comment;
-
     if (simpleKeys) {
       if (keyComment) {
         throw new Error('With simple keys, key nodes cannot have comments');
       }
-
       if (key instanceof Collection) {
         const msg = 'With simple keys, collection cannot be used as a key value';
         throw new Error(msg);
       }
     }
-
     let explicitKey = !simpleKeys && (!key || keyComment || (key instanceof Node ? key instanceof Collection || key.type === PlainValue.Type.BLOCK_FOLDED || key.type === PlainValue.Type.BLOCK_LITERAL : typeof key === 'object'));
     const {
       doc,
@@ -10964,70 +11091,54 @@ class Pair extends Node {
     let chompKeep = false;
     let str = stringify(key, ctx, () => keyComment = null, () => chompKeep = true);
     str = addComment(str, ctx.indent, keyComment);
-
     if (!explicitKey && str.length > 1024) {
       if (simpleKeys) throw new Error('With simple keys, single line scalar must not span more than 1024 characters');
       explicitKey = true;
     }
-
     if (ctx.allNullValues && !simpleKeys) {
       if (this.comment) {
         str = addComment(str, ctx.indent, this.comment);
         if (onComment) onComment();
       } else if (chompKeep && !keyComment && onChompKeep) onChompKeep();
-
       return ctx.inFlow && !explicitKey ? str : `? ${str}`;
     }
-
     str = explicitKey ? `? ${str}\n${indent}:` : `${str}:`;
-
     if (this.comment) {
       // expected (but not strictly required) to be a single-line comment
       str = addComment(str, ctx.indent, this.comment);
       if (onComment) onComment();
     }
-
     let vcb = '';
     let valueComment = null;
-
     if (value instanceof Node) {
       if (value.spaceBefore) vcb = '\n';
-
       if (value.commentBefore) {
         const cs = value.commentBefore.replace(/^/gm, `${ctx.indent}#`);
         vcb += `\n${cs}`;
       }
-
       valueComment = value.comment;
     } else if (value && typeof value === 'object') {
       value = doc.schema.createNode(value, true);
     }
-
     ctx.implicitKey = false;
     if (!explicitKey && !this.comment && value instanceof Scalar) ctx.indentAtStart = str.length + 1;
     chompKeep = false;
-
     if (!indentSeq && indentSize >= 2 && !ctx.inFlow && !explicitKey && value instanceof YAMLSeq && value.type !== PlainValue.Type.FLOW_SEQ && !value.tag && !doc.anchors.getName(value)) {
       // If indentSeq === false, consider '- ' as part of indentation where possible
       ctx.indent = ctx.indent.substr(2);
     }
-
     const valueStr = stringify(value, ctx, () => valueComment = null, () => chompKeep = true);
     let ws = ' ';
-
     if (vcb || this.comment) {
       ws = `${vcb}\n${ctx.indent}`;
     } else if (!explicitKey && value instanceof Collection) {
       const flow = valueStr[0] === '[' || valueStr[0] === '{';
       if (!flow || valueStr.includes('\n')) ws = `\n${ctx.indent}`;
     } else if (valueStr[0] === '\n') ws = '';
-
     if (chompKeep && !valueComment && onChompKeep) onChompKeep();
     return addComment(str + ws + valueStr, ctx.indent, valueComment);
   }
-
 }
-
 PlainValue._defineProperty(Pair, "Type", {
   PAIR: 'PAIR',
   MERGE_PAIR: 'MERGE_PAIR'
@@ -11039,22 +11150,18 @@ const getAliasCount = (node, anchors) => {
     return anchor.count * anchor.aliasCount;
   } else if (node instanceof Collection) {
     let count = 0;
-
     for (const item of node.items) {
       const c = getAliasCount(item, anchors);
       if (c > count) count = c;
     }
-
     return count;
   } else if (node instanceof Pair) {
     const kc = getAliasCount(node.key, anchors);
     const vc = getAliasCount(node.value, anchors);
     return Math.max(kc, vc);
   }
-
   return 1;
 };
-
 class Alias extends Node {
   static stringify({
     range,
@@ -11071,17 +11178,14 @@ class Alias extends Node {
     const msg = doc.anchors.getName(source) ? 'Alias node must be after source node' : 'Source node not found for alias node';
     throw new Error(`${msg} [${range}]`);
   }
-
   constructor(source) {
     super();
     this.source = source;
     this.type = PlainValue.Type.ALIAS;
   }
-
   set tag(t) {
     throw new Error('Alias nodes cannot have tags');
   }
-
   toJSON(arg, ctx) {
     if (!ctx) return toJSON(this.source, arg, ctx);
     const {
@@ -11090,45 +11194,37 @@ class Alias extends Node {
     } = ctx;
     const anchor = anchors.get(this.source);
     /* istanbul ignore if */
-
     if (!anchor || anchor.res === undefined) {
       const msg = 'This should not happen: Alias anchor was not resolved?';
       if (this.cstNode) throw new PlainValue.YAMLReferenceError(this.cstNode, msg);else throw new ReferenceError(msg);
     }
-
     if (maxAliasCount >= 0) {
       anchor.count += 1;
       if (anchor.aliasCount === 0) anchor.aliasCount = getAliasCount(this.source, anchors);
-
       if (anchor.count * anchor.aliasCount > maxAliasCount) {
         const msg = 'Excessive alias count indicates a resource exhaustion attack';
         if (this.cstNode) throw new PlainValue.YAMLReferenceError(this.cstNode, msg);else throw new ReferenceError(msg);
       }
     }
-
     return anchor.res;
-  } // Only called when stringifying an alias mapping key while constructing
+  }
+
+  // Only called when stringifying an alias mapping key while constructing
   // Object output.
-
-
   toString(ctx) {
     return Alias.stringify(this, ctx);
   }
-
 }
-
 PlainValue._defineProperty(Alias, "default", true);
 
 function findPair(items, key) {
   const k = key instanceof Scalar ? key.value : key;
-
   for (const it of items) {
     if (it instanceof Pair) {
       if (it.key === key || it.key === k) return it;
       if (it.key && it.key.value === k) return it;
     }
   }
-
   return undefined;
 }
 class YAMLMap extends Collection {
@@ -11136,7 +11232,6 @@ class YAMLMap extends Collection {
     if (!pair) pair = new Pair(pair);else if (!(pair instanceof Pair)) pair = new Pair(pair.key || pair, pair.value);
     const prev = findPair(this.items, pair.key);
     const sortEntries = this.schema && this.schema.sortMapEntries;
-
     if (prev) {
       if (overwrite) prev.value = pair.value;else throw new Error(`Key ${pair.key} already set`);
     } else if (sortEntries) {
@@ -11146,51 +11241,41 @@ class YAMLMap extends Collection {
       this.items.push(pair);
     }
   }
-
   delete(key) {
     const it = findPair(this.items, key);
     if (!it) return false;
     const del = this.items.splice(this.items.indexOf(it), 1);
     return del.length > 0;
   }
-
   get(key, keepScalar) {
     const it = findPair(this.items, key);
     const node = it && it.value;
     return !keepScalar && node instanceof Scalar ? node.value : node;
   }
-
   has(key) {
     return !!findPair(this.items, key);
   }
-
   set(key, value) {
     this.add(new Pair(key, value), true);
   }
+
   /**
    * @param {*} arg ignored
    * @param {*} ctx Conversion context, originally set in Document#toJSON()
    * @param {Class} Type If set, forces the returned collection type
    * @returns {*} Instance of Type, Map, or Object
    */
-
-
   toJSON(_, ctx, Type) {
     const map = Type ? new Type() : ctx && ctx.mapAsMap ? new Map() : {};
     if (ctx && ctx.onCreate) ctx.onCreate(map);
-
     for (const item of this.items) item.addToJSMap(ctx, map);
-
     return map;
   }
-
   toString(ctx, onComment, onChompKeep) {
     if (!ctx) return JSON.stringify(this);
-
     for (const item of this.items) {
       if (!(item instanceof Pair)) throw new Error(`Map items must all be pairs; found ${JSON.stringify(item)} instead`);
     }
-
     return super.toString(ctx, {
       blockItem: n => n.str,
       flowChars: {
@@ -11201,7 +11286,6 @@ class YAMLMap extends Collection {
       itemIndent: ctx.indent || ''
     }, onComment, onChompKeep);
   }
-
 }
 
 const MERGE_KEY = '<<';
@@ -11209,36 +11293,32 @@ class Merge extends Pair {
   constructor(pair) {
     if (pair instanceof Pair) {
       let seq = pair.value;
-
       if (!(seq instanceof YAMLSeq)) {
         seq = new YAMLSeq();
         seq.items.push(pair.value);
         seq.range = pair.value.range;
       }
-
       super(pair.key, seq);
       this.range = pair.range;
     } else {
       super(new Scalar(MERGE_KEY), new YAMLSeq());
     }
-
     this.type = Pair.Type.MERGE_PAIR;
-  } // If the value associated with a merge key is a single mapping node, each of
+  }
+
+  // If the value associated with a merge key is a single mapping node, each of
   // its key/value pairs is inserted into the current mapping, unless the key
   // already exists in it. If the value associated with the merge key is a
   // sequence, then this sequence is expected to contain mapping nodes and each
   // of these nodes is merged in turn according to its order in the sequence.
   // Keys in mapping nodes earlier in the sequence override keys specified in
   // later mapping nodes. -- http://yaml.org/type/merge.html
-
-
   addToJSMap(ctx, map) {
     for (const {
       source
     } of this.value.items) {
       if (!(source instanceof YAMLMap)) throw new Error('Merge sources must be maps');
       const srcMap = source.toJSON(null, ctx, Map);
-
       for (const [key, value] of srcMap) {
         if (map instanceof Map) {
           if (!map.has(key)) map.set(key, value);
@@ -11254,10 +11334,8 @@ class Merge extends Pair {
         }
       }
     }
-
     return map;
   }
-
   toString(ctx, onComment) {
     const seq = this.value;
     if (seq.items.length > 1) return super.toString(ctx, onComment);
@@ -11266,7 +11344,6 @@ class Merge extends Pair {
     this.value = seq;
     return str;
   }
-
 }
 
 const binaryOptions = {
@@ -11295,6 +11372,7 @@ const strOptions = {
   }
 };
 
+// falls back to string on no match
 function resolveScalar(str, tags, scalarFallback) {
   for (const {
     format,
@@ -11303,7 +11381,6 @@ function resolveScalar(str, tags, scalarFallback) {
   } of tags) {
     if (test) {
       const match = str.match(test);
-
       if (match) {
         let res = resolve.apply(null, match);
         if (!(res instanceof Scalar)) res = new Scalar(res);
@@ -11312,29 +11389,27 @@ function resolveScalar(str, tags, scalarFallback) {
       }
     }
   }
-
   if (scalarFallback) str = scalarFallback(str);
   return new Scalar(str);
 }
 
 const FOLD_FLOW = 'flow';
 const FOLD_BLOCK = 'block';
-const FOLD_QUOTED = 'quoted'; // presumes i+1 is at the start of a line
-// returns index of last newline in more-indented block
+const FOLD_QUOTED = 'quoted';
 
+// presumes i+1 is at the start of a line
+// returns index of last newline in more-indented block
 const consumeMoreIndentedLines = (text, i) => {
   let ch = text[i + 1];
-
   while (ch === ' ' || ch === '\t') {
     do {
       ch = text[i += 1];
     } while (ch && ch !== '\n');
-
     ch = text[i + 1];
   }
-
   return i;
 };
+
 /**
  * Tries to keep input at up to `lineWidth` characters, splitting only on spaces
  * not followed by newlines or spaces unless `mode` is `'quoted'`. Lines are
@@ -11355,8 +11430,6 @@ const consumeMoreIndentedLines = (text, i) => {
  * @param {function} options.onFold Called once if any line of text exceeds
  *   lineWidth characters
  */
-
-
 function foldFlowLines(text, indent, mode, {
   indentAtStart,
   lineWidth = 80,
@@ -11370,47 +11443,37 @@ function foldFlowLines(text, indent, mode, {
   const folds = [];
   const escapedFolds = {};
   let end = lineWidth - indent.length;
-
   if (typeof indentAtStart === 'number') {
     if (indentAtStart > lineWidth - Math.max(2, minContentWidth)) folds.push(0);else end = lineWidth - indentAtStart;
   }
-
   let split = undefined;
   let prev = undefined;
   let overflow = false;
   let i = -1;
   let escStart = -1;
   let escEnd = -1;
-
   if (mode === FOLD_BLOCK) {
     i = consumeMoreIndentedLines(text, i);
     if (i !== -1) end = i + endStep;
   }
-
   for (let ch; ch = text[i += 1];) {
     if (mode === FOLD_QUOTED && ch === '\\') {
       escStart = i;
-
       switch (text[i + 1]) {
         case 'x':
           i += 3;
           break;
-
         case 'u':
           i += 5;
           break;
-
         case 'U':
           i += 9;
           break;
-
         default:
           i += 1;
       }
-
       escEnd = i;
     }
-
     if (ch === '\n') {
       if (mode === FOLD_BLOCK) i = consumeMoreIndentedLines(text, i);
       end = i + endStep;
@@ -11421,7 +11484,6 @@ function foldFlowLines(text, indent, mode, {
         const next = text[i + 1];
         if (next && next !== ' ' && next !== '\n' && next !== '\t') split = i;
       }
-
       if (i >= end) {
         if (split) {
           folds.push(split);
@@ -11433,11 +11495,10 @@ function foldFlowLines(text, indent, mode, {
             prev = ch;
             ch = text[i += 1];
             overflow = true;
-          } // Account for newline escape, but don't break preceding escape
-
-
-          const j = i > escEnd + 1 ? i - 2 : escStart - 1; // Bail out if lineWidth & minContentWidth are shorter than an escape string
-
+          }
+          // Account for newline escape, but don't break preceding escape
+          const j = i > escEnd + 1 ? i - 2 : escStart - 1;
+          // Bail out if lineWidth & minContentWidth are shorter than an escape string
           if (escapedFolds[j]) return text;
           folds.push(j);
           escapedFolds[j] = true;
@@ -11448,15 +11509,12 @@ function foldFlowLines(text, indent, mode, {
         }
       }
     }
-
     prev = ch;
   }
-
   if (overflow && onOverflow) onOverflow();
   if (folds.length === 0) return text;
   if (onFold) onFold();
   let res = text.slice(0, folds[0]);
-
   for (let i = 0; i < folds.length; ++i) {
     const fold = folds[i];
     const end = folds[i + 1] || text.length;
@@ -11465,7 +11523,6 @@ function foldFlowLines(text, indent, mode, {
       res += `\n${indent}${text.slice(fold + 1, end)}`;
     }
   }
-
   return res;
 }
 
@@ -11473,18 +11530,16 @@ const getFoldOptions = ({
   indentAtStart
 }) => indentAtStart ? Object.assign({
   indentAtStart
-}, strOptions.fold) : strOptions.fold; // Also checks for lines starting with %, as parsing the output as YAML 1.1 will
+}, strOptions.fold) : strOptions.fold;
+
+// Also checks for lines starting with %, as parsing the output as YAML 1.1 will
 // presume that's starting a new document.
-
-
 const containsDocumentMarker = str => /^(%|---|\.\.\.)/m.test(str);
-
 function lineLengthOverLimit(str, lineWidth, indentLength) {
   if (!lineWidth || lineWidth < 0) return false;
   const limit = lineWidth - indentLength;
   const strLen = str.length;
   if (strLen <= limit) return false;
-
   for (let i = 0, start = 0; i < strLen; ++i) {
     if (str[i] === '\n') {
       if (i - start > limit) return true;
@@ -11492,10 +11547,8 @@ function lineLengthOverLimit(str, lineWidth, indentLength) {
       if (strLen - start <= limit) return false;
     }
   }
-
   return true;
 }
-
 function doubleQuotedString(value, ctx) {
   const {
     implicitKey
@@ -11509,7 +11562,6 @@ function doubleQuotedString(value, ctx) {
   const indent = ctx.indent || (containsDocumentMarker(value) ? '  ' : '');
   let str = '';
   let start = 0;
-
   for (let i = 0, ch = json[i]; ch; ch = json[++i]) {
     if (ch === ' ' && json[i + 1] === '\\' && json[i + 2] === 'n') {
       // space before newline needs to be escaped to not be folded
@@ -11518,85 +11570,67 @@ function doubleQuotedString(value, ctx) {
       start = i;
       ch = '\\';
     }
-
     if (ch === '\\') switch (json[i + 1]) {
       case 'u':
         {
           str += json.slice(start, i);
           const code = json.substr(i + 2, 4);
-
           switch (code) {
             case '0000':
               str += '\\0';
               break;
-
             case '0007':
               str += '\\a';
               break;
-
             case '000b':
               str += '\\v';
               break;
-
             case '001b':
               str += '\\e';
               break;
-
             case '0085':
               str += '\\N';
               break;
-
             case '00a0':
               str += '\\_';
               break;
-
             case '2028':
               str += '\\L';
               break;
-
             case '2029':
               str += '\\P';
               break;
-
             default:
               if (code.substr(0, 2) === '00') str += '\\x' + code.substr(2);else str += json.substr(i, 6);
           }
-
           i += 5;
           start = i + 1;
         }
         break;
-
       case 'n':
         if (implicitKey || json[i + 2] === '"' || json.length < minMultiLineLength) {
           i += 1;
         } else {
           // folding will eat first newline
           str += json.slice(start, i) + '\n\n';
-
           while (json[i + 2] === '\\' && json[i + 3] === 'n' && json[i + 4] !== '"') {
             str += '\n';
             i += 2;
           }
-
-          str += indent; // space after newline needs to be escaped to not be folded
-
+          str += indent;
+          // space after newline needs to be escaped to not be folded
           if (json[i + 2] === ' ') str += '\\';
           i += 1;
           start = i + 1;
         }
-
         break;
-
       default:
         i += 1;
     }
   }
-
   str = start ? str + json.slice(start) : json;
   return implicitKey ? str : foldFlowLines(str, indent, FOLD_QUOTED, getFoldOptions(ctx));
 }
-
 function singleQuotedString(value, ctx) {
   if (ctx.implicitKey) {
     if (/\n/.test(value)) return doubleQuotedString(value, ctx);
@@ -11604,12 +11638,10 @@ function singleQuotedString(value, ctx) {
     // single quoted string can't have leading or trailing whitespace around newline
     if (/[ \t]\n|\n[ \t]/.test(value)) return doubleQuotedString(value, ctx);
   }
-
   const indent = ctx.indent || (containsDocumentMarker(value) ? '  ' : '');
   const res = "'" + value.replace(/'/g, "''").replace(/\n+/g, `$&\n${indent}`) + "'";
   return ctx.implicitKey ? res : foldFlowLines(res, indent, FOLD_FLOW, getFoldOptions(ctx));
 }
-
 function blockString({
   comment,
   type,
@@ -11620,10 +11652,8 @@ function blockString({
   if (/\n[\t ]+$/.test(value) || /^\s*$/.test(value)) {
     return doubleQuotedString(value, ctx);
   }
-
   const indent = ctx.indent || (ctx.forceBlockIndent || containsDocumentMarker(value) ? '  ' : '');
   const indentSize = indent ? '2' : '1'; // root is at -1
-
   const literal = type === PlainValue.Type.BLOCK_FOLDED ? false : type === PlainValue.Type.BLOCK_LITERAL ? true : !lineLengthOverLimit(value, strOptions.fold.lineWidth, indent.length);
   let header = literal ? '|' : '>';
   if (!value) return header + '\n';
@@ -11631,21 +11661,17 @@ function blockString({
   let wsEnd = '';
   value = value.replace(/[\n\t ]*$/, ws => {
     const n = ws.indexOf('\n');
-
     if (n === -1) {
       header += '-'; // strip
     } else if (value === ws || n !== ws.length - 1) {
       header += '+'; // keep
-
       if (onChompKeep) onChompKeep();
     }
-
     wsEnd = ws.replace(/\n$/, '');
     return '';
   }).replace(/^[\n ]*/, ws => {
     if (ws.indexOf(' ') !== -1) header += indentSize;
     const m = ws.match(/ +$/);
-
     if (m) {
       wsStart = ws.slice(0, -m[0].length);
       return m[0];
@@ -11656,26 +11682,21 @@ function blockString({
   });
   if (wsEnd) wsEnd = wsEnd.replace(/\n+(?!\n|$)/g, `$&${indent}`);
   if (wsStart) wsStart = wsStart.replace(/\n+/g, `$&${indent}`);
-
   if (comment) {
     header += ' #' + comment.replace(/ ?[\r\n]+/g, ' ');
     if (onComment) onComment();
   }
-
   if (!value) return `${header}${indentSize}\n${indent}${wsEnd}`;
-
   if (literal) {
     value = value.replace(/\n+/g, `$&${indent}`);
     return `${header}\n${indent}${wsStart}${value}${wsEnd}`;
   }
-
   value = value.replace(/\n+/g, '\n$&').replace(/(?:^|\n)([\t ].*)(?:([\n\t ]*)\n(?![\n\t ]))?/g, '$1$2') // more-indented lines aren't folded
   //         ^ ind.line  ^ empty     ^ capture next empty lines only at end of indent
   .replace(/\n+/g, `$&${indent}`);
   const body = foldFlowLines(`${wsStart}${value}${wsEnd}`, indent, FOLD_BLOCK, strOptions.fold);
   return `${header}\n${indent}${body}`;
 }
-
 function plainString(item, ctx, onComment, onChompKeep) {
   const {
     comment,
@@ -11688,11 +11709,9 @@ function plainString(item, ctx, onComment, onChompKeep) {
     indent,
     inFlow
   } = ctx;
-
   if (implicitKey && /[\n[\]{},]/.test(value) || inFlow && /[[\]{},]/.test(value)) {
     return doubleQuotedString(value, ctx);
   }
-
   if (!value || /^[\n\t ,[\]{}#&*!|>'"%@`]|^[?-]$|^[?-][ \t]|[\n:][ \t]|[ \t]\n|[\n\t ]#|[\n\t :]$/.test(value)) {
     // not allowed:
     // - empty string, '-' or '?'
@@ -11702,21 +11721,18 @@ function plainString(item, ctx, onComment, onChompKeep) {
     // - end with ' ' or ':'
     return implicitKey || inFlow || value.indexOf('\n') === -1 ? value.indexOf('"') !== -1 && value.indexOf("'") === -1 ? singleQuotedString(value, ctx) : doubleQuotedString(value, ctx) : blockString(item, ctx, onComment, onChompKeep);
   }
-
   if (!implicitKey && !inFlow && type !== PlainValue.Type.PLAIN && value.indexOf('\n') !== -1) {
     // Where allowed & type not set explicitly, prefer block style for multiline strings
     return blockString(item, ctx, onComment, onChompKeep);
   }
-
   if (indent === '' && containsDocumentMarker(value)) {
     ctx.forceBlockIndent = true;
     return blockString(item, ctx, onComment, onChompKeep);
   }
-
-  const str = value.replace(/\n+/g, `$&\n${indent}`); // Verify that output will be parsed as a string, as e.g. plain numbers and
+  const str = value.replace(/\n+/g, `$&\n${indent}`);
+  // Verify that output will be parsed as a string, as e.g. plain numbers and
   // booleans get parsed with those types in v1.2 (e.g. '42', 'true' & '0.9e-3'),
   // and others in v1.1.
-
   if (actualString) {
     const {
       tags
@@ -11724,17 +11740,13 @@ function plainString(item, ctx, onComment, onChompKeep) {
     const resolved = resolveScalar(str, tags, tags.scalarFallback).value;
     if (typeof resolved !== 'string') return doubleQuotedString(value, ctx);
   }
-
   const body = implicitKey ? str : foldFlowLines(str, indent, FOLD_FLOW, getFoldOptions(ctx));
-
   if (comment && !inFlow && (body.indexOf('\n') !== -1 || comment.indexOf('\n') !== -1)) {
     if (onComment) onComment();
     return addCommentBefore(body, indent, comment);
   }
-
   return body;
 }
-
 function stringifyString(item, ctx, onComment, onChompKeep) {
   const {
     defaultType
@@ -11747,34 +11759,27 @@ function stringifyString(item, ctx, onComment, onChompKeep) {
     type,
     value
   } = item;
-
   if (typeof value !== 'string') {
     value = String(value);
     item = Object.assign({}, item, {
       value
     });
   }
-
   const _stringify = _type => {
     switch (_type) {
       case PlainValue.Type.BLOCK_FOLDED:
       case PlainValue.Type.BLOCK_LITERAL:
         return blockString(item, ctx, onComment, onChompKeep);
-
       case PlainValue.Type.QUOTE_DOUBLE:
         return doubleQuotedString(value, ctx);
-
       case PlainValue.Type.QUOTE_SINGLE:
         return singleQuotedString(value, ctx);
-
       case PlainValue.Type.PLAIN:
         return plainString(item, ctx, onComment, onChompKeep);
-
       default:
         return null;
     }
   };
-
   if (type !== PlainValue.Type.QUOTE_DOUBLE && /[\x00-\x08\x0b-\x1f\x7f-\x9f]/.test(value)) {
     // force double quotes on control characters
     type = PlainValue.Type.QUOTE_DOUBLE;
@@ -11782,14 +11787,11 @@ function stringifyString(item, ctx, onComment, onChompKeep) {
     // should not happen; blocks are not valid inside flow containers
     type = PlainValue.Type.QUOTE_DOUBLE;
   }
-
   let res = _stringify(type);
-
   if (res === null) {
     res = _stringify(defaultType);
     if (res === null) throw new Error(`Unsupported default string type ${defaultType}`);
   }
-
   return res;
 }
 
@@ -11802,57 +11804,44 @@ function stringifyNumber({
   if (typeof value === 'bigint') return String(value);
   if (!isFinite(value)) return isNaN(value) ? '.nan' : value < 0 ? '-.inf' : '.inf';
   let n = JSON.stringify(value);
-
   if (!format && minFractionDigits && (!tag || tag === 'tag:yaml.org,2002:float') && /^\d/.test(n)) {
     let i = n.indexOf('.');
-
     if (i < 0) {
       i = n.length;
       n += '.';
     }
-
     let d = minFractionDigits - (n.length - i - 1);
-
     while (d-- > 0) n += '0';
   }
-
   return n;
 }
 
 function checkFlowCollectionEnd(errors, cst) {
   let char, name;
-
   switch (cst.type) {
     case PlainValue.Type.FLOW_MAP:
       char = '}';
       name = 'flow map';
       break;
-
     case PlainValue.Type.FLOW_SEQ:
       char = ']';
       name = 'flow sequence';
       break;
-
     default:
       errors.push(new PlainValue.YAMLSemanticError(cst, 'Not a flow collection!?'));
       return;
   }
-
   let lastItem;
-
   for (let i = cst.items.length - 1; i >= 0; --i) {
     const item = cst.items[i];
-
     if (!item || item.type !== PlainValue.Type.COMMENT) {
       lastItem = item;
       break;
     }
   }
-
   if (lastItem && lastItem.char !== char) {
     const msg = `Expected ${name} to end with ${char}`;
     let err;
-
     if (typeof lastItem.offset === 'number') {
       err = new PlainValue.YAMLSemanticError(cst, msg);
       err.offset = lastItem.offset + 1;
@@ -11860,13 +11849,11 @@ function checkFlowCollectionEnd(errors, cst) {
       err = new PlainValue.YAMLSemanticError(lastItem, msg);
       if (lastItem.range && lastItem.range.end) err.offset = lastItem.range.end - lastItem.range.start;
     }
-
     errors.push(err);
   }
 }
 function checkFlowCommentSpace(errors, comment) {
   const prev = comment.context.src[comment.range.start - 1];
-
   if (prev !== '\n' && prev !== '\t' && prev !== ' ') {
     const msg = 'Comments must be separated from other tokens by white space characters';
     errors.push(new PlainValue.YAMLSemanticError(comment, msg));
@@ -11884,14 +11871,12 @@ function resolveComments(collection, comments) {
     comment
   } of comments) {
     let item = collection.items[before];
-
     if (!item) {
       if (comment !== undefined) {
         if (collection.comment) collection.comment += '\n' + comment;else collection.comment = comment;
       }
     } else {
       if (afterKey && item.value) item = item.value;
-
       if (comment === undefined) {
         if (afterKey || !item.commentBefore) item.spaceBefore = true;
       } else {
@@ -11919,45 +11904,37 @@ function resolveTagHandle(doc, node) {
     suffix
   } = node.tag;
   let prefix = doc.tagPrefixes.find(p => p.handle === handle);
-
   if (!prefix) {
     const dtp = doc.getDefaults().tagPrefixes;
     if (dtp) prefix = dtp.find(p => p.handle === handle);
     if (!prefix) throw new PlainValue.YAMLSemanticError(node, `The ${handle} tag handle is non-default and was not declared.`);
   }
-
   if (!suffix) throw new PlainValue.YAMLSemanticError(node, `The ${handle} tag has no suffix.`);
-
   if (handle === '!' && (doc.version || doc.options.version) === '1.0') {
     if (suffix[0] === '^') {
       doc.warnings.push(new PlainValue.YAMLWarning(node, 'YAML 1.0 ^ tag expansion is not supported'));
       return suffix;
     }
-
     if (/[:/]/.test(suffix)) {
       // word/foo -> tag:word.yaml.org,2002:foo
       const vocab = suffix.match(/^([a-z0-9-]+)\/(.*)/i);
       return vocab ? `tag:${vocab[1]}.yaml.org,2002:${vocab[2]}` : `tag:${suffix}`;
     }
   }
-
   return prefix.prefix + decodeURIComponent(suffix);
 }
-
 function resolveTagName(doc, node) {
   const {
     tag,
     type
   } = node;
   let nonSpecific = false;
-
   if (tag) {
     const {
       handle,
       suffix,
       verbatim
     } = tag;
-
     if (verbatim) {
       if (verbatim !== '!' && verbatim !== '!!') return verbatim;
       const msg = `Verbatim tags aren't resolved, so ${verbatim} is invalid.`;
@@ -11972,25 +11949,20 @@ function resolveTagName(doc, node) {
       }
     }
   }
-
   switch (type) {
     case PlainValue.Type.BLOCK_FOLDED:
     case PlainValue.Type.BLOCK_LITERAL:
     case PlainValue.Type.QUOTE_DOUBLE:
     case PlainValue.Type.QUOTE_SINGLE:
       return PlainValue.defaultTags.STR;
-
     case PlainValue.Type.FLOW_MAP:
     case PlainValue.Type.MAP:
       return PlainValue.defaultTags.MAP;
-
     case PlainValue.Type.FLOW_SEQ:
     case PlainValue.Type.SEQ:
       return PlainValue.defaultTags.SEQ;
-
     case PlainValue.Type.PLAIN:
       return nonSpecific ? PlainValue.defaultTags.STR : null;
-
     default:
       return null;
   }
@@ -12001,7 +11973,6 @@ function resolveByTagName(doc, node, tagName) {
     tags
   } = doc.schema;
   const matchWithTest = [];
-
   for (const tag of tags) {
     if (tag.tag === tagName) {
       if (tag.test) matchWithTest.push(tag);else {
@@ -12010,12 +11981,10 @@ function resolveByTagName(doc, node, tagName) {
       }
     }
   }
-
   const str = resolveString(doc, node);
   if (typeof str === 'string' && matchWithTest.length > 0) return resolveScalar(str, matchWithTest, tags.scalarFallback);
   return null;
 }
-
 function getFallbackTagName({
   type
 }) {
@@ -12023,31 +11992,30 @@ function getFallbackTagName({
     case PlainValue.Type.FLOW_MAP:
     case PlainValue.Type.MAP:
       return PlainValue.defaultTags.MAP;
-
     case PlainValue.Type.FLOW_SEQ:
     case PlainValue.Type.SEQ:
       return PlainValue.defaultTags.SEQ;
-
     default:
       return PlainValue.defaultTags.STR;
   }
 }
-
 function resolveTag(doc, node, tagName) {
   try {
     const res = resolveByTagName(doc, node, tagName);
-
     if (res) {
       if (tagName && node.tag) res.tag = tagName;
       return res;
     }
   } catch (error) {
-    /* istanbul ignore if */
-    if (!error.source) error.source = node;
-    doc.errors.push(error);
+    if (error instanceof PlainValue.YAMLError) {
+      if (!error.source) error.source = node;
+      doc.errors.push(error);
+    } else {
+      const msg = error instanceof Error ? error.message : String(error);
+      doc.errors.push(new PlainValue.YAMLSemanticError(node, msg));
+    }
     return null;
   }
-
   try {
     const fallback = getFallbackTagName(node);
     if (!fallback) throw new Error(`The tag ${tagName} is unavailable`);
@@ -12071,7 +12039,6 @@ const isCollectionItem = node => {
   } = node;
   return type === PlainValue.Type.MAP_KEY || type === PlainValue.Type.MAP_VALUE || type === PlainValue.Type.SEQ_ITEM;
 };
-
 function resolveNodeProps(errors, node) {
   const comments = {
     before: [],
@@ -12080,7 +12047,6 @@ function resolveNodeProps(errors, node) {
   let hasAnchor = false;
   let hasTag = false;
   const props = isCollectionItem(node.context.parent) ? node.context.parent.props.concat(node.props) : node.props;
-
   for (const {
     start,
     end
@@ -12092,7 +12058,6 @@ function resolveNodeProps(errors, node) {
             const msg = 'Comments must be separated from other tokens by white space characters';
             errors.push(new PlainValue.YAMLSemanticError(node, msg));
           }
-
           const {
             header,
             valueRange
@@ -12101,69 +12066,57 @@ function resolveNodeProps(errors, node) {
           cc.push(node.context.src.slice(start + 1, end));
           break;
         }
-      // Actual anchor & tag resolution is handled by schema, here we just complain
 
+      // Actual anchor & tag resolution is handled by schema, here we just complain
       case PlainValue.Char.ANCHOR:
         if (hasAnchor) {
           const msg = 'A node can have at most one anchor';
           errors.push(new PlainValue.YAMLSemanticError(node, msg));
         }
-
         hasAnchor = true;
         break;
-
       case PlainValue.Char.TAG:
         if (hasTag) {
           const msg = 'A node can have at most one tag';
           errors.push(new PlainValue.YAMLSemanticError(node, msg));
         }
-
         hasTag = true;
         break;
     }
   }
-
   return {
     comments,
     hasAnchor,
     hasTag
   };
 }
-
 function resolveNodeValue(doc, node) {
   const {
     anchors,
     errors,
     schema
   } = doc;
-
   if (node.type === PlainValue.Type.ALIAS) {
     const name = node.rawValue;
     const src = anchors.getNode(name);
-
     if (!src) {
       const msg = `Aliased anchor not found: ${name}`;
       errors.push(new PlainValue.YAMLReferenceError(node, msg));
       return null;
-    } // Lazy resolution for circular references
+    }
 
-
+    // Lazy resolution for circular references
     const res = new Alias(src);
-
     anchors._cstAliases.push(res);
-
     return res;
   }
-
   const tagName = resolveTagName(doc, node);
   if (tagName) return resolveTag(doc, node, tagName);
-
   if (node.type !== PlainValue.Type.PLAIN) {
     const msg = `Failed to resolve ${node.type} node here`;
     errors.push(new PlainValue.YAMLSyntaxError(node, msg));
     return null;
   }
-
   try {
     const str = resolveString(doc, node);
     return resolveScalar(str, schema.tags, schema.tags.scalarFallback);
@@ -12172,9 +12125,9 @@ function resolveNodeValue(doc, node) {
     errors.push(error);
     return null;
   }
-} // sets node.resolved on success
+}
 
-
+// sets node.resolved on success
 function resolveNode(doc, node) {
   if (!node) return null;
   if (node.error) doc.errors.push(node.error);
@@ -12183,43 +12136,36 @@ function resolveNode(doc, node) {
     hasAnchor,
     hasTag
   } = resolveNodeProps(doc.errors, node);
-
   if (hasAnchor) {
     const {
       anchors
     } = doc;
     const name = node.anchor;
-    const prev = anchors.getNode(name); // At this point, aliases for any preceding node with the same anchor
+    const prev = anchors.getNode(name);
+    // At this point, aliases for any preceding node with the same anchor
     // name have already been resolved, so it may safely be renamed.
-
-    if (prev) anchors.map[anchors.newName(name)] = prev; // During parsing, we need to store the CST node in anchors.map as
+    if (prev) anchors.map[anchors.newName(name)] = prev;
+    // During parsing, we need to store the CST node in anchors.map as
     // anchors need to be available during resolution to allow for
     // circular references.
-
     anchors.map[name] = node;
   }
-
   if (node.type === PlainValue.Type.ALIAS && (hasAnchor || hasTag)) {
     const msg = 'An alias node must not specify any properties';
     doc.errors.push(new PlainValue.YAMLSemanticError(node, msg));
   }
-
   const res = resolveNodeValue(doc, node);
-
   if (res) {
     res.range = [node.range.start, node.range.end];
     if (doc.options.keepCstNodes) res.cstNode = node;
     if (doc.options.keepNodeTypes) res.type = node.type;
     const cb = comments.before.join('\n');
-
     if (cb) {
       res.commentBefore = res.commentBefore ? `${res.commentBefore}\n${cb}` : cb;
     }
-
     const ca = comments.after.join('\n');
     if (ca) res.comment = res.comment ? `${res.comment}\n${ca}` : ca;
   }
-
   return node.resolved = res;
 }
 
@@ -12229,7 +12175,6 @@ function resolveMap(doc, cst) {
     doc.errors.push(new PlainValue.YAMLSyntaxError(cst, msg));
     return null;
   }
-
   const {
     comments,
     items
@@ -12238,13 +12183,11 @@ function resolveMap(doc, cst) {
   map.items = items;
   resolveComments(map, comments);
   let hasCollectionKey = false;
-
   for (let i = 0; i < items.length; ++i) {
     const {
       key: iKey
     } = items[i];
     if (iKey instanceof Collection) hasCollectionKey = true;
-
     if (doc.schema.merge && iKey && iKey.value === MERGE_KEY) {
       items[i] = new Merge(items[i]);
       const sources = items[i].value.items;
@@ -12259,7 +12202,6 @@ function resolveMap(doc, cst) {
           if (type === PlainValue.Type.MAP || type === PlainValue.Type.FLOW_MAP) return false;
           return error = 'Merge nodes aliases can only point to maps';
         }
-
         return error = 'Merge nodes can only have Alias nodes as values';
       });
       if (error) doc.errors.push(new PlainValue.YAMLSemanticError(cst, error));
@@ -12268,7 +12210,6 @@ function resolveMap(doc, cst) {
         const {
           key: jKey
         } = items[j];
-
         if (iKey === jKey || iKey && jKey && Object.prototype.hasOwnProperty.call(iKey, 'value') && iKey.value === jKey.value) {
           const msg = `Map keys must be unique; "${iKey}" is repeated`;
           doc.errors.push(new PlainValue.YAMLSemanticError(cst, msg));
@@ -12277,16 +12218,13 @@ function resolveMap(doc, cst) {
       }
     }
   }
-
   if (hasCollectionKey && !doc.options.mapAsMap) {
     const warn = 'Keys with collection values will be stringified as YAML due to JS Object restrictions. Use mapAsMap: true to avoid this.';
     doc.warnings.push(new PlainValue.YAMLWarning(cst, warn));
   }
-
   cst.resolved = map;
   return map;
 }
-
 const valueHasPairComment = ({
   context: {
     lineStart,
@@ -12301,42 +12239,33 @@ const valueHasPairComment = ({
   } = props[0];
   if (node && start > node.valueRange.start) return false;
   if (src[start] !== PlainValue.Char.COMMENT) return false;
-
   for (let i = lineStart; i < start; ++i) if (src[i] === '\n') return false;
-
   return true;
 };
-
 function resolvePairComment(item, pair) {
   if (!valueHasPairComment(item)) return;
   const comment = item.getPropValue(0, PlainValue.Char.COMMENT, true);
   let found = false;
   const cb = pair.value.commentBefore;
-
   if (cb && cb.startsWith(comment)) {
     pair.value.commentBefore = cb.substr(comment.length + 1);
     found = true;
   } else {
     const cc = pair.value.comment;
-
     if (!item.node && cc && cc.startsWith(comment)) {
       pair.value.comment = cc.substr(comment.length + 1);
       found = true;
     }
   }
-
   if (found) pair.comment = comment;
 }
-
 function resolveBlockMapItems(doc, cst) {
   const comments = [];
   const items = [];
   let key = undefined;
   let keyStart = null;
-
   for (let i = 0; i < cst.items.length; ++i) {
     const item = cst.items[i];
-
     switch (item.type) {
       case PlainValue.Type.BLANK_LINE:
         comments.push({
@@ -12344,7 +12273,6 @@ function resolveBlockMapItems(doc, cst) {
           before: items.length
         });
         break;
-
       case PlainValue.Type.COMMENT:
         comments.push({
           afterKey: !!key,
@@ -12352,26 +12280,21 @@ function resolveBlockMapItems(doc, cst) {
           comment: item.comment
         });
         break;
-
       case PlainValue.Type.MAP_KEY:
         if (key !== undefined) items.push(new Pair(key));
         if (item.error) doc.errors.push(item.error);
         key = resolveNode(doc, item.node);
         keyStart = null;
         break;
-
       case PlainValue.Type.MAP_VALUE:
         {
           if (key === undefined) key = null;
           if (item.error) doc.errors.push(item.error);
-
           if (!item.context.atLineStart && item.node && item.node.type === PlainValue.Type.MAP && !item.node.context.atLineStart) {
             const msg = 'Nested mappings are not allowed in compact mappings';
             doc.errors.push(new PlainValue.YAMLSemanticError(item.node, msg));
           }
-
           let valueNode = item.node;
-
           if (!valueNode && item.props.length > 0) {
             // Comments on an empty mapping value need to be preserved, so we
             // need to construct a minimal empty node here to use instead of the
@@ -12390,44 +12313,35 @@ function resolveBlockMapItems(doc, cst) {
               start: pos,
               end: pos
             };
-
             if (typeof item.range.origStart === 'number') {
               const origPos = item.range.origStart + 1;
               valueNode.range.origStart = valueNode.range.origEnd = origPos;
               valueNode.valueRange.origStart = valueNode.valueRange.origEnd = origPos;
             }
           }
-
           const pair = new Pair(key, resolveNode(doc, valueNode));
           resolvePairComment(item, pair);
           items.push(pair);
-
           if (key && typeof keyStart === 'number') {
             if (item.range.start > keyStart + 1024) doc.errors.push(getLongKeyError(cst, key));
           }
-
           key = undefined;
           keyStart = null;
         }
         break;
-
       default:
         if (key !== undefined) items.push(new Pair(key));
         key = resolveNode(doc, item);
         keyStart = item.range.start;
         if (item.error) doc.errors.push(item.error);
-
         next: for (let j = i + 1;; ++j) {
           const nextItem = cst.items[j];
-
           switch (nextItem && nextItem.type) {
             case PlainValue.Type.BLANK_LINE:
             case PlainValue.Type.COMMENT:
               continue next;
-
             case PlainValue.Type.MAP_VALUE:
               break next;
-
             default:
               {
                 const msg = 'Implicit map keys need to be followed by map values';
@@ -12436,47 +12350,38 @@ function resolveBlockMapItems(doc, cst) {
               }
           }
         }
-
         if (item.valueRangeContainsNewline) {
           const msg = 'Implicit map keys need to be on a single line';
           doc.errors.push(new PlainValue.YAMLSemanticError(item, msg));
         }
-
     }
   }
-
   if (key !== undefined) items.push(new Pair(key));
   return {
     comments,
     items
   };
 }
-
 function resolveFlowMapItems(doc, cst) {
   const comments = [];
   const items = [];
   let key = undefined;
   let explicitKey = false;
   let next = '{';
-
   for (let i = 0; i < cst.items.length; ++i) {
     const item = cst.items[i];
-
     if (typeof item.char === 'string') {
       const {
         char,
         offset
       } = item;
-
       if (char === '?' && key === undefined && !explicitKey) {
         explicitKey = true;
         next = ':';
         continue;
       }
-
       if (char === ':') {
         if (key === undefined) key = null;
-
         if (next === ':') {
           next = ',';
           continue;
@@ -12486,25 +12391,21 @@ function resolveFlowMapItems(doc, cst) {
           if (key === undefined && char !== ',') key = null;
           explicitKey = false;
         }
-
         if (key !== undefined) {
           items.push(new Pair(key));
           key = undefined;
-
           if (char === ',') {
             next = ':';
             continue;
           }
         }
       }
-
       if (char === '}') {
         if (i === cst.items.length - 1) continue;
       } else if (char === next) {
         next = ':';
         continue;
       }
-
       const msg = `Flow map contains an unexpected ${char}`;
       const err = new PlainValue.YAMLSyntaxError(cst, msg);
       err.offset = offset;
@@ -12531,7 +12432,6 @@ function resolveFlowMapItems(doc, cst) {
       explicitKey = false;
     }
   }
-
   checkFlowCollectionEnd(doc.errors, cst);
   if (key !== undefined) items.push(new Pair(key));
   return {
@@ -12546,7 +12446,6 @@ function resolveSeq(doc, cst) {
     doc.errors.push(new PlainValue.YAMLSyntaxError(cst, msg));
     return null;
   }
-
   const {
     comments,
     items
@@ -12554,60 +12453,48 @@ function resolveSeq(doc, cst) {
   const seq = new YAMLSeq();
   seq.items = items;
   resolveComments(seq, comments);
-
   if (!doc.options.mapAsMap && items.some(it => it instanceof Pair && it.key instanceof Collection)) {
     const warn = 'Keys with collection values will be stringified as YAML due to JS Object restrictions. Use mapAsMap: true to avoid this.';
     doc.warnings.push(new PlainValue.YAMLWarning(cst, warn));
   }
-
   cst.resolved = seq;
   return seq;
 }
-
 function resolveBlockSeqItems(doc, cst) {
   const comments = [];
   const items = [];
-
   for (let i = 0; i < cst.items.length; ++i) {
     const item = cst.items[i];
-
     switch (item.type) {
       case PlainValue.Type.BLANK_LINE:
         comments.push({
           before: items.length
         });
         break;
-
       case PlainValue.Type.COMMENT:
         comments.push({
           comment: item.comment,
           before: items.length
         });
         break;
-
       case PlainValue.Type.SEQ_ITEM:
         if (item.error) doc.errors.push(item.error);
         items.push(resolveNode(doc, item.node));
-
         if (item.hasProps) {
           const msg = 'Sequence items cannot have tags or anchors before the - indicator';
           doc.errors.push(new PlainValue.YAMLSemanticError(item, msg));
         }
-
         break;
-
       default:
         if (item.error) doc.errors.push(item.error);
         doc.errors.push(new PlainValue.YAMLSyntaxError(item, `Unexpected ${item.type} node in sequence`));
     }
   }
-
   return {
     comments,
     items
   };
 }
-
 function resolveFlowSeqItems(doc, cst) {
   const comments = [];
   const items = [];
@@ -12616,16 +12503,13 @@ function resolveFlowSeqItems(doc, cst) {
   let keyStart = null;
   let next = '[';
   let prevItem = null;
-
   for (let i = 0; i < cst.items.length; ++i) {
     const item = cst.items[i];
-
     if (typeof item.char === 'string') {
       const {
         char,
         offset
       } = item;
-
       if (char !== ':' && (explicitKey || key !== undefined)) {
         if (explicitKey && key === undefined) key = next ? items.pop() : null;
         items.push(new Pair(key));
@@ -12633,7 +12517,6 @@ function resolveFlowSeqItems(doc, cst) {
         key = undefined;
         keyStart = null;
       }
-
       if (char === next) {
         next = null;
       } else if (!next && char === '?') {
@@ -12641,21 +12524,18 @@ function resolveFlowSeqItems(doc, cst) {
       } else if (next !== '[' && char === ':' && key === undefined) {
         if (next === ',') {
           key = items.pop();
-
           if (key instanceof Pair) {
             const msg = 'Chaining flow sequence pairs is invalid';
             const err = new PlainValue.YAMLSemanticError(cst, msg);
             err.offset = offset;
             doc.errors.push(err);
           }
-
           if (!explicitKey && typeof keyStart === 'number') {
             const keyEnd = item.range ? item.range.start : item.offset;
             if (keyEnd > keyStart + 1024) doc.errors.push(getLongKeyError(cst, key));
             const {
               src
             } = prevItem.context;
-
             for (let i = keyStart; i < keyEnd; ++i) if (src[i] === '\n') {
               const msg = 'Implicit keys of flow sequence pairs need to be on a single line';
               doc.errors.push(new PlainValue.YAMLSemanticError(prevItem, msg));
@@ -12665,7 +12545,6 @@ function resolveFlowSeqItems(doc, cst) {
         } else {
           key = null;
         }
-
         keyStart = null;
         explicitKey = false;
         next = null;
@@ -12690,9 +12569,7 @@ function resolveFlowSeqItems(doc, cst) {
         const msg = `Expected a ${next} in flow sequence`;
         doc.errors.push(new PlainValue.YAMLSemanticError(item, msg));
       }
-
       const value = resolveNode(doc, item);
-
       if (key === undefined) {
         items.push(value);
         prevItem = item;
@@ -12700,12 +12577,10 @@ function resolveFlowSeqItems(doc, cst) {
         items.push(new Pair(key, value));
         key = undefined;
       }
-
       keyStart = item.range.start;
       next = ',';
     }
   }
-
   checkFlowCollectionEnd(doc.errors, cst);
   if (key !== undefined) items.push(new Pair(key));
   return {
@@ -12741,14 +12616,14 @@ exports.toJSON = toJSON;
 
 /***/ }),
 
-/***/ 1747:
+/***/ 5058:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var PlainValue = __nccwpck_require__(1346);
-var resolveSeq = __nccwpck_require__(1011);
+var PlainValue = __nccwpck_require__(9609);
+var resolveSeq = __nccwpck_require__(9091);
 
 /* global atob, btoa, Buffer */
 const binary = {
@@ -12756,7 +12631,6 @@ const binary = {
   // Buffer inherits from Uint8Array
   default: false,
   tag: 'tag:yaml.org,2002:binary',
-
   /**
    * Returns a Buffer in node and an Uint8Array in browsers
    *
@@ -12767,16 +12641,13 @@ const binary = {
    */
   resolve: (doc, node) => {
     const src = resolveSeq.resolveString(doc, node);
-
     if (typeof Buffer === 'function') {
       return Buffer.from(src, 'base64');
     } else if (typeof atob === 'function') {
       // On IE 11, atob() can't handle newlines
       const str = atob(src.replace(/[\n\r]/g, ''));
       const buffer = new Uint8Array(str.length);
-
       for (let i = 0; i < str.length; ++i) buffer[i] = str.charCodeAt(i);
-
       return buffer;
     } else {
       const msg = 'This environment does not support reading binary tags; either Buffer or atob is required';
@@ -12791,21 +12662,16 @@ const binary = {
     value
   }, ctx, onComment, onChompKeep) => {
     let src;
-
     if (typeof Buffer === 'function') {
       src = value instanceof Buffer ? value.toString('base64') : Buffer.from(value.buffer).toString('base64');
     } else if (typeof btoa === 'function') {
       let s = '';
-
       for (let i = 0; i < value.length; ++i) s += String.fromCharCode(value[i]);
-
       src = btoa(s);
     } else {
       throw new Error('This environment does not support writing binary tags; either Buffer or btoa is required');
     }
-
     if (!type) type = resolveSeq.binaryOptions.defaultType;
-
     if (type === PlainValue.Type.QUOTE_DOUBLE) {
       value = src;
     } else {
@@ -12814,14 +12680,11 @@ const binary = {
       } = resolveSeq.binaryOptions;
       const n = Math.ceil(src.length / lineWidth);
       const lines = new Array(n);
-
       for (let i = 0, o = 0; i < n; ++i, o += lineWidth) {
         lines[i] = src.substr(o, lineWidth);
       }
-
       value = lines.join(type === PlainValue.Type.BLOCK_LITERAL ? '\n' : ' ');
     }
-
     return resolveSeq.stringifyString({
       comment,
       type,
@@ -12832,7 +12695,6 @@ const binary = {
 
 function parsePairs(doc, cst) {
   const seq = resolveSeq.resolveSeq(doc, cst);
-
   for (let i = 0; i < seq.items.length; ++i) {
     let item = seq.items[i];
     if (item instanceof resolveSeq.Pair) continue;else if (item instanceof resolveSeq.YAMLMap) {
@@ -12840,7 +12702,6 @@ function parsePairs(doc, cst) {
         const msg = 'Each pair must have its own sequence indicator';
         throw new PlainValue.YAMLSemanticError(cst, msg);
       }
-
       const pair = item.items[0] || new resolveSeq.Pair();
       if (item.commentBefore) pair.commentBefore = pair.commentBefore ? `${item.commentBefore}\n${pair.commentBefore}` : item.commentBefore;
       if (item.comment) pair.comment = pair.comment ? `${item.comment}\n${pair.comment}` : item.comment;
@@ -12848,16 +12709,13 @@ function parsePairs(doc, cst) {
     }
     seq.items[i] = item instanceof resolveSeq.Pair ? item : new resolveSeq.Pair(item);
   }
-
   return seq;
 }
 function createPairs(schema, iterable, ctx) {
   const pairs = new resolveSeq.YAMLSeq(schema);
   pairs.tag = 'tag:yaml.org,2002:pairs';
-
   for (const it of iterable) {
     let key, value;
-
     if (Array.isArray(it)) {
       if (it.length === 2) {
         key = it[0];
@@ -12865,7 +12723,6 @@ function createPairs(schema, iterable, ctx) {
       } else throw new TypeError(`Expected [key, value] tuple: ${it}`);
     } else if (it && it instanceof Object) {
       const keys = Object.keys(it);
-
       if (keys.length === 1) {
         key = keys[0];
         value = it[key];
@@ -12873,11 +12730,9 @@ function createPairs(schema, iterable, ctx) {
     } else {
       key = it;
     }
-
     const pair = schema.createPair(key, value, ctx);
     pairs.items.push(pair);
   }
-
   return pairs;
 }
 const pairs = {
@@ -12890,49 +12745,34 @@ const pairs = {
 class YAMLOMap extends resolveSeq.YAMLSeq {
   constructor() {
     super();
-
     PlainValue._defineProperty(this, "add", resolveSeq.YAMLMap.prototype.add.bind(this));
-
     PlainValue._defineProperty(this, "delete", resolveSeq.YAMLMap.prototype.delete.bind(this));
-
     PlainValue._defineProperty(this, "get", resolveSeq.YAMLMap.prototype.get.bind(this));
-
     PlainValue._defineProperty(this, "has", resolveSeq.YAMLMap.prototype.has.bind(this));
-
     PlainValue._defineProperty(this, "set", resolveSeq.YAMLMap.prototype.set.bind(this));
-
     this.tag = YAMLOMap.tag;
   }
-
   toJSON(_, ctx) {
     const map = new Map();
     if (ctx && ctx.onCreate) ctx.onCreate(map);
-
     for (const pair of this.items) {
       let key, value;
-
       if (pair instanceof resolveSeq.Pair) {
         key = resolveSeq.toJSON(pair.key, '', ctx);
         value = resolveSeq.toJSON(pair.value, key, ctx);
       } else {
         key = resolveSeq.toJSON(pair, '', ctx);
       }
-
       if (map.has(key)) throw new Error('Ordered maps must not include duplicate keys');
       map.set(key, value);
     }
-
     return map;
   }
-
 }
-
 PlainValue._defineProperty(YAMLOMap, "tag", 'tag:yaml.org,2002:omap');
-
 function parseOMap(doc, cst) {
   const pairs = parsePairs(doc, cst);
   const seenKeys = [];
-
   for (const {
     key
   } of pairs.items) {
@@ -12945,17 +12785,14 @@ function parseOMap(doc, cst) {
       }
     }
   }
-
   return Object.assign(new YAMLOMap(), pairs);
 }
-
 function createOMap(schema, iterable, ctx) {
   const pairs = createPairs(schema, iterable, ctx);
   const omap = new YAMLOMap();
   omap.items = pairs.items;
   return omap;
 }
-
 const omap = {
   identify: value => value instanceof Map,
   nodeClass: YAMLOMap,
@@ -12970,56 +12807,43 @@ class YAMLSet extends resolveSeq.YAMLMap {
     super();
     this.tag = YAMLSet.tag;
   }
-
   add(key) {
     const pair = key instanceof resolveSeq.Pair ? key : new resolveSeq.Pair(key);
     const prev = resolveSeq.findPair(this.items, pair.key);
     if (!prev) this.items.push(pair);
   }
-
   get(key, keepPair) {
     const pair = resolveSeq.findPair(this.items, key);
     return !keepPair && pair instanceof resolveSeq.Pair ? pair.key instanceof resolveSeq.Scalar ? pair.key.value : pair.key : pair;
   }
-
   set(key, value) {
     if (typeof value !== 'boolean') throw new Error(`Expected boolean value for set(key, value) in a YAML set, not ${typeof value}`);
     const prev = resolveSeq.findPair(this.items, key);
-
     if (prev && !value) {
       this.items.splice(this.items.indexOf(prev), 1);
     } else if (!prev && value) {
       this.items.push(new resolveSeq.Pair(key));
     }
   }
-
   toJSON(_, ctx) {
     return super.toJSON(_, ctx, Set);
   }
-
   toString(ctx, onComment, onChompKeep) {
     if (!ctx) return JSON.stringify(this);
     if (this.hasAllNullValues()) return super.toString(ctx, onComment, onChompKeep);else throw new Error('Set items must all have null values');
   }
-
 }
-
 PlainValue._defineProperty(YAMLSet, "tag", 'tag:yaml.org,2002:set');
-
 function parseSet(doc, cst) {
   const map = resolveSeq.resolveMap(doc, cst);
   if (!map.hasAllNullValues()) throw new PlainValue.YAMLSemanticError(cst, 'Set items must all have null values');
   return Object.assign(new YAMLSet(), map);
 }
-
 function createSet(schema, iterable, ctx) {
   const set = new YAMLSet();
-
   for (const value of iterable) set.items.push(schema.createPair(value, null, ctx));
-
   return set;
 }
-
 const set = {
   identify: value => value instanceof Set,
   nodeClass: YAMLSet,
@@ -13032,38 +12856,32 @@ const set = {
 const parseSexagesimal = (sign, parts) => {
   const n = parts.split(':').reduce((n, p) => n * 60 + Number(p), 0);
   return sign === '-' ? -n : n;
-}; // hhhh:mm:ss.sss
+};
 
-
+// hhhh:mm:ss.sss
 const stringifySexagesimal = ({
   value
 }) => {
   if (isNaN(value) || !isFinite(value)) return resolveSeq.stringifyNumber(value);
   let sign = '';
-
   if (value < 0) {
     sign = '-';
     value = Math.abs(value);
   }
-
   const parts = [value % 60]; // seconds, including ms
-
   if (value < 60) {
     parts.unshift(0); // at least one : is required
   } else {
     value = Math.round((value - parts[0]) / 60);
     parts.unshift(value % 60); // minutes
-
     if (value >= 60) {
       value = Math.round((value - parts[0]) / 60);
       parts.unshift(value); // hours
     }
   }
-
   return sign + parts.map(n => n < 10 ? '0' + String(n) : String(n)).join(':').replace(/000000\d*$/, '') // % 60 may introduce error
-  ;
+;
 };
-
 const intTime = {
   identify: value => typeof value === 'number',
   default: true,
@@ -13089,21 +12907,23 @@ const timestamp = {
   // If the time zone is omitted, the timestamp is assumed to be specified in UTC. The time part
   // may be omitted altogether, resulting in a date format. In such a case, the time part is
   // assumed to be 00:00:00Z (start of day, UTC).
-  test: RegExp('^(?:' + '([0-9]{4})-([0-9]{1,2})-([0-9]{1,2})' + // YYYY-Mm-Dd
-  '(?:(?:t|T|[ \\t]+)' + // t | T | whitespace
-  '([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2}(\\.[0-9]+)?)' + // Hh:Mm:Ss(.ss)?
-  '(?:[ \\t]*(Z|[-+][012]?[0-9](?::[0-9]{2})?))?' + // Z | +5 | -03:30
+  test: RegExp('^(?:' + '([0-9]{4})-([0-9]{1,2})-([0-9]{1,2})' +
+  // YYYY-Mm-Dd
+  '(?:(?:t|T|[ \\t]+)' +
+  // t | T | whitespace
+  '([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2}(\\.[0-9]+)?)' +
+  // Hh:Mm:Ss(.ss)?
+  '(?:[ \\t]*(Z|[-+][012]?[0-9](?::[0-9]{2})?))?' +
+  // Z | +5 | -03:30
   ')?' + ')$'),
   resolve: (str, year, month, day, hour, minute, second, millisec, tz) => {
     if (millisec) millisec = (millisec + '00').substr(1, 3);
     let date = Date.UTC(year, month - 1, day, hour || 0, minute || 0, second || 0, millisec || 0);
-
     if (tz && tz !== 'Z') {
       let d = parseSexagesimal(tz[0], tz.slice(1));
       if (Math.abs(d) < 30) d *= 60;
       date -= 60000 * d;
     }
-
     return new Date(date);
   },
   stringify: ({
@@ -13112,23 +12932,21 @@ const timestamp = {
 };
 
 /* global console, process, YAML_SILENCE_DEPRECATION_WARNINGS, YAML_SILENCE_WARNINGS */
+
 function shouldWarn(deprecation) {
   const env = typeof process !== 'undefined' && process.env || {};
-
   if (deprecation) {
     if (typeof YAML_SILENCE_DEPRECATION_WARNINGS !== 'undefined') return !YAML_SILENCE_DEPRECATION_WARNINGS;
     return !env.YAML_SILENCE_DEPRECATION_WARNINGS;
   }
-
   if (typeof YAML_SILENCE_WARNINGS !== 'undefined') return !YAML_SILENCE_WARNINGS;
   return !env.YAML_SILENCE_WARNINGS;
 }
-
 function warn(warning, type) {
   if (shouldWarn(false)) {
-    const emit = typeof process !== 'undefined' && process.emitWarning; // This will throw in Jest if `warning` is an Error instance due to
+    const emit = typeof process !== 'undefined' && process.emitWarning;
+    // This will throw in Jest if `warning` is an Error instance due to
     // https://github.com/facebook/jest/issues/2549
-
     if (emit) emit(warning, type);else {
       // eslint-disable-next-line no-console
       console.warn(type ? `${type}: ${warning}` : warning);

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1,102 +1,64 @@
-<p align="center">
-  <a href="https://github.com/actions/javascript-action/actions"><img alt="javscript-action status" src="https://github.com/actions/javascript-action/workflows/units-test/badge.svg"></a>
-</p>
+# Maintainer Guide
 
-# Create a JavaScript Action
+This document covers local development and releasing _Changelog Reader Action_.
+For end-user documentation, see the [README](../README.md).
 
-## Code in Develop
+## Local development
 
-Install the dependencies:
-
-```bash
-$ npm install
-```
-
-Run the tests:
+Install dependencies and run the test suite:
 
 ```bash
-$ npm test
-
- PASS  ./index.test.js
-  ✓ throws invalid number (3ms)
-  ✓ wait 500 ms (504ms)
-  ✓ test runs (95ms)
-
-...
+npm ci
+npm test
 ```
 
-## Change the Code
+`npm test` runs ESLint over `src/` followed by the Jest suite. All tests live next
+to the file they exercise (`src/foo.js` ↔ `src/foo.test.js`).
 
-Most toolkit and CI/CD operations involve async operations so the action is run in an async function.
-
-```javascript
-const core = require('@actions/core');
-...
-
-async function run() {
-  try {
-      ...
-  }
-  catch (error) {
-    core.setFailed(error.message);
-  }
-}
-
-run()
-```
-
-See the [toolkit documentation](https://github.com/actions/toolkit/blob/master/README.md#packages) for the various packages.
-
-## Package for distribution
-
-GitHub Actions will run the entry point from the action.yml. Packaging assembles the code into one file that can be checked in to Git, enabling fast and reliable execution and preventing the need to check in node_modules.
-
-Actions are run from GitHub repos. Packaging the action will create a packaged action in the `dist` folder.
-
-Run package:
+To rebuild the bundled action output after changing anything in `src/`:
 
 ```bash
-npm run package
+npm run build
 ```
 
-Since the packaged `index.js` is ran from the `dist` folder.
+This runs `@vercel/ncc` to bundle `index.js` and its dependencies into a single
+`dist/index.js` file. The `prepare` script in `package.json` runs the same
+command automatically on `npm install`, so the bundle stays in sync as long as
+you install before committing.
 
-```bash
-git add dist
-```
+## Why `dist/` is committed
 
-## Create a release tags
+GitHub Actions written in JavaScript run directly from the action repository at
+the SHA a consumer pins — there is no install step on the runner. The bundled
+`dist/index.js` is therefore the artifact that actually executes for every
+caller. CI enforces this with a drift check: after running the test suite, it
+re-runs `npm run build` and fails if the result differs from what is committed.
+If you see that step fail, run `npm run build` locally and commit the updated
+bundle.
 
-Changelog Reader follow semantic versionning. So you have to create your tag.
+## Releasing a new version
 
-```bash
-$ git tag -s v1.0.3
-```
+The action follows [Semantic Versioning](https://semver.org/). Releases also
+maintain a floating major-version tag (`v2`) so consumers can pin to
+`mindsers/changelog-reader-action@v2` and pick up patches automatically.
 
-To ease the work of maintainer we also create (or update) shortcut tags:
+1. Make sure the `Unreleased` section in `CHANGELOG.md` accurately reflects what
+   you are about to ship; move its contents under a new
+   `## [X.Y.Z] - YYYY-MM-DD` heading.
+2. Bump the `version` field in `package.json`.
+3. Commit the version bump and CHANGELOG update on `master`.
+4. Tag the exact version and move the floating major tag:
 
-```bash
-$ git tag -d v1
-$ git push --delete origin v1
-$ git tag -a v1
-```
+   ```bash
+   git tag -s vX.Y.Z -m "Release X.Y.Z"
+   git tag -f vX
+   git push origin vX.Y.Z
+   git push origin vX --force
+   ```
 
-```bash
-$ git push --tags
-```
+5. Create the matching GitHub Release for `vX.Y.Z`, with the new CHANGELOG
+   section as the release body, and tick the "Publish this Action to the
+   GitHub Marketplace" box.
 
-Now you have to create the GitHub Release for this new version (v1.0.3) and check "marketplace". This action is now published! :rocket:
-
-See the [versioning documentation](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md)
-
-## Usage
-
-You can now consume the action by referencing the v1 branch:
-
-```yaml
-uses: actions/javascript-action@v1
-with:
-  milliseconds: 1000
-```
-
-See the [actions tab](https://github.com/actions/javascript-action/actions) for runs of this action! :rocket:
+For background on action versioning, see
+[actions/toolkit's versioning guide](https://github.com/actions/toolkit/blob/main/docs/action-versioning.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",
+        "semver": "^7.6.0",
         "yaml": "^1.10.3"
       },
       "devDependencies": {
@@ -17,8 +18,7 @@
         "@types/semver": "^7.3.13",
         "@vercel/ncc": "^0.38.4",
         "eslint": "^8.27.0",
-        "jest": "^29.3.1",
-        "semver": "^7.3.8"
+        "jest": "^29.3.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3276,7 +3276,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3846,7 +3845,6 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4242,8 +4240,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.3",
@@ -6753,7 +6750,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -7146,7 +7142,6 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -7428,8 +7423,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.3",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,15 @@
     "url": "https://nathanaelcherrier.com"
   },
   "scripts": {
+    "build": "ncc build index.js -o dist",
     "lint": "eslint src/**/*.js",
-    "package": "ncc build index.js -o dist",
+    "package": "npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest"
   },
   "dependencies": {
     "@actions/core": "^1.11.1",
+    "semver": "^7.6.0",
     "yaml": "^1.10.3"
   },
   "devDependencies": {
@@ -31,8 +34,7 @@
     "@types/semver": "^7.3.13",
     "@vercel/ncc": "^0.38.4",
     "eslint": "^8.27.0",
-    "jest": "^29.3.1",
-    "semver": "^7.3.8"
+    "jest": "^29.3.1"
   },
   "keywords": [
     "GitHub",

--- a/src/get-entries.js
+++ b/src/get-entries.js
@@ -1,5 +1,3 @@
-const core = require('@actions/core')
-
 const versionSeparator = '\n## '
 const semverLinkRegex =
   /^\[v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?\]/
@@ -9,8 +7,6 @@ const avoidNonVersionData = version =>
 
 exports.getEntries = rawData => {
   const content = String(rawData)
-
-  core.debug(`CHANGELOG content: ${content}`)
 
   return content.split(versionSeparator).filter(avoidNonVersionData)
 }

--- a/src/get-links.js
+++ b/src/get-links.js
@@ -1,13 +1,9 @@
-const core = require('@actions/core')
-
 const linkRegex =
   /^\[.+\]:\s?(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/
 const avoidNonVersionData = text => linkRegex.test(text)
 
 exports.getLinks = rawData => {
   const content = String(rawData)
-
-  core.debug(`CHANGELOG content: ${content}`)
 
   return content.trim().split('\n').filter(avoidNonVersionData)
 }


### PR DESCRIPTION
## Summary

First in a series of maintenance passes. Pure hygiene — no behavior change for consumers, `v2` tag is intentionally **not** moved.

- **`chore(deps)`** Declare `semver` as a runtime dependency. It was in `devDependencies` but `require`d at runtime by `src/parse-entry.js` and the rules under `src/rules/` — only worked because `@vercel/ncc` inlined it into `dist/index.js`. Anyone running the source directly would have hit `Cannot find module 'semver'`.
- **`ci`** Add a `dist/` drift check to the `unit` job: re-runs `npm run build` after the test suite and fails if the committed bundle differs. Also add explicit `build` and `prepare` npm scripts so the bundle is rebuilt automatically on `npm install`.
- **`refactor`** Stop dumping the entire CHANGELOG content to `core.debug` from `get-entries` and `get-links` (the same wall of text twice per run with `ACTIONS_STEP_DEBUG=true`).
- **`docs`** Rewrite `docs/how-to.md` as a real maintainer guide — it was a verbatim copy of the `actions/javascript-action` template, still referencing `milliseconds: 1000` and an unrelated repo. Fix three "Configfile" leftovers in `CONTRIBUTING.md`.
- **`docs(changelog)`** Record the user-visible changes (Node 24 runtime, semver dep, debug noise) under `## [Unreleased]`. Cutting an actual release is deferred.
- **`build`** Regenerate `dist/index.js` with the current `@vercel/ncc@^0.38.4`.

## Test plan

- [ ] `unit` job passes (lint + jest + new drift check)
- [ ] `e2e` job still produces non-empty output from this repo's own CHANGELOG (this is the consumer-impact gate — if the dist rebuild changes runtime behavior, this is where it shows up)
- [ ] `git ls-remote --tags origin v2` resolves to the same SHA before and after merge
- [ ] `node -e "require('./src/parse-entry')"` loads without `Cannot find module 'semver'`
- [ ] Diff of `dist/index.js` reviewed — the rebuild surface area is mostly TypeScript helper updates from the newer `@actions/core` and a few `(0, fn)()` call-form changes; no logic changes from this repo's `src/`